### PR TITLE
fix: useSpaceList pagination wrapper and useCollections refetch loop

### DIFF
--- a/packages/core/src/hooks/collections/useCollections.ts
+++ b/packages/core/src/hooks/collections/useCollections.ts
@@ -106,12 +106,16 @@ function useCollections(_: UseCollectionsProps = {}): UseCollectionsValues {
     }
   }, [dispatch, projectId, currentProjectId]);
 
-  // Fetch root collection when user and project are available
+  // Fetch root collection when user and project are available.
+  // Skip if a collection is already loaded for this project — otherwise mounting
+  // useCollections() per leaf component (e.g. a BookmarkButton in every card)
+  // hammers /collections/root and trips the rate limit.
   useEffect(() => {
     if (!user || !projectId) return;
+    if (currentCollection && currentProjectId === projectId) return;
 
     fetchRootCollection({ projectId });
-  }, [fetchRootCollection, user, projectId]);
+  }, [fetchRootCollection, user, projectId, currentCollection, currentProjectId]);
 
   // Fetch sub-collections when current collection changes
   useEffect(() => {

--- a/packages/core/src/store/api/spacesApi.ts
+++ b/packages/core/src/store/api/spacesApi.ts
@@ -196,6 +196,9 @@ export const spacesApi = baseApi.injectEndpoints({
           method: "GET",
         };
       },
+      // API returns { data: Space[], pagination }; unwrap so consumers get Space[].
+      transformResponse: (response: { data: Space[] } | Space[]) =>
+        Array.isArray(response) ? response : response.data,
       providesTags: (result) => [
         { type: "Space", id: "LIST" },
         ...(result?.map(({ id }) => ({ type: "Space" as const, id })) ?? []),


### PR DESCRIPTION
Two high-severity v7 bugs we hit migrating a production React + Vite app to `@replyke/react-js@7.0.0`. These are split out from a larger triage report so they can land independently of the smaller permissions/export fixes (#3).

## #1 — `useSpaceList` silently renders empty (paginated-response wrapper bug)

`spacesApi.fetchSpaces` had no `transformResponse`. The API returns `{ data: Space[], pagination }`, but the lazy-query result is passed straight to `setSpaceListSpaces({ ..., spaces: result, append })` in `useSpaceListActions`, where `spaces` is expected to be `Space[]`. So the whole wrapper object lands in Redux state as `list.spaces`, which means:
- `spaces.map(...)` iterates the wrapper's enumerable keys → page renders empty
- `result.length >= options.limit` is `undefined >= N` → `hasMore` is permanently `false`

**Fix:** add `transformResponse` to unwrap `{ data, pagination }` so consumers get `Space[]` (matching the existing query type signature). Defensively handle both shapes in case the server response evolves.

**Reproduce (before the fix):**
```ts
const { fetchSpaces } = useSpaceListActions();
await fetchSpaces("my-list", { page: 1, limit: 20, sortBy: "newest" });
// Redux state: list.spaces = { data: [...], pagination: {...} } ← wrapper, not array
```

## #2 — `useCollections()` re-fetches the root collection on every mount

The fetch effect in `useCollections.ts` didn't short-circuit when the root collection was already loaded. Mounting `useCollections()` from a `BookmarkButton` per card (or from a `MoveToListMenu` per saved row) hammered `/collections/root` and tripped the rate limit (429) within seconds of opening a feed.

**Fix:** skip the root fetch if a `currentCollection` is already loaded for the current `projectId`. The existing project-context effect handles project switches by updating `currentProjectId`, which naturally invalidates the cache check.

**Workaround we used in app code (no longer needed):** lift `useCollections()` to a single app-level provider, expose values via context, and have leaves use `useCollectionsActions()` for writes only.

## Test plan

- [ ] `useSpaceList({ listId }).fetchSpaces({ page: 1, limit: 20, sortBy: "newest" }, { fetchImmediately: true })` populates `spaces` with the array of spaces from the project
- [ ] `hasMore` is `true` when results == limit, `false` when results < limit
- [ ] Mount `useCollections()` from N leaf components on a feed page → only one `/collections/root` request fires
- [ ] Switching `projectId` in `ReplykeProvider` still triggers a fresh root fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)