### PR TITLE
🐛 fix(expo): use `_` separator in AccountManager SecureStore key

### DIFF
--- a/packages/expo/src/AccountManager.tsx
+++ b/packages/expo/src/AccountManager.tsx
@@ -2,7 +2,9 @@ import * as SecureStore from "expo-secure-store";
 import { useAccountSync, useProject, handleError } from "@sublay/core";
 import type { AccountStorage, AccountMap } from "@sublay/core";
 
-const STORAGE_KEY_PREFIX = "sublay-accounts:";
+// expo-secure-store rejects keys containing `:` on iOS — keys must match
+// /^[A-Za-z0-9._-]+$/. Use `_` as the separator instead.
+const STORAGE_KEY_PREFIX = "sublay-accounts_";
 
 const secureStoreStorage: AccountStorage = {
   async getAccountMap(projectId: string): Promise<AccountMap | null> {


### PR DESCRIPTION
Apple's SecureStore rejects keys containing `:` — keys must match /^[A-Za-z0-9._-]+$/. The previous prefix `replyke-accounts:` caused every iOS write to fail with "Invalid key provided to SecureStore", so the multi-account map was never persisted and sessions did not survive cold restarts.

- Change STORAGE_KEY_PREFIX from "replyke-accounts:" to "replyke-accounts_"
- Add an inline note explaining the iOS constraint so the colon doesn't get reintroduced

No data-migration concern: prior writes never succeeded on iOS, so there is no orphaned keychain entry to clean up.

Fixes #9

Authored-By: Jenova Marie <jenova-marie@pm.me>