### PR TITLE
🐛 fix(core): stop sending parentSpaceId=null in useSpaceList queries

### DIFF
--- a/packages/core/src/hooks/space-lists/useSpaceList.ts
+++ b/packages/core/src/hooks/space-lists/useSpaceList.ts
@@ -150,7 +150,9 @@ function useSpaceList({ listId }: UseSpaceListProps): UseSpaceListValues {
           searchAny: null,
           readingPermission: null,
           memberOf: false,
-          parentSpaceId: null,
+          // undefined (not null) so the serializer omits the param entirely
+          // for top-level / unfiltered listings.
+          parentSpaceId: undefined as any,
         };
         const finalFilters = { ...currentState };
 
@@ -163,7 +165,8 @@ function useSpaceList({ listId }: UseSpaceListProps): UseSpaceListValues {
           finalFilters.searchAny = null;
           finalFilters.readingPermission = null;
           finalFilters.memberOf = false;
-          finalFilters.parentSpaceId = null;
+          // See note on currentState default — undefined, not null.
+          finalFilters.parentSpaceId = undefined as any;
         }
 
         // Apply new filters

--- a/packages/core/src/store/api/spacesApi.ts
+++ b/packages/core/src/store/api/spacesApi.ts
@@ -187,9 +187,11 @@ export const spacesApi = baseApi.injectEndpoints({
         if (params.searchAny) queryParams.append("searchAny", params.searchAny);
         if (params.readingPermission) queryParams.append("readingPermission", params.readingPermission);
         if (params.memberOf !== undefined) queryParams.append("memberOf", params.memberOf.toString());
-        if (params.parentSpaceId !== undefined) {
-          // Convert null to "null" string for API
-          queryParams.append("parentSpaceId", params.parentSpaceId === null ? "null" : params.parentSpaceId);
+        // Only emit parentSpaceId when an actual ID is provided. The server
+        // treats the absence of the param as "top-level only" and rejects
+        // the literal string "null" as an invalid UUID with 400.
+        if (params.parentSpaceId) {
+          queryParams.append("parentSpaceId", params.parentSpaceId);
         }
 
         return {


### PR DESCRIPTION
The spaces query serializer was emitting the literal string "null" when no parent was specified, which the API rejects as an invalid UUID with HTTP 400. The hook also forced parentSpaceId back to null on every fetch path, so there was no way for a caller to opt out of the bad value. Result: root-level space listing via useSpaceList was unusable for the entire v7 release.

- spacesApi.fetchSpaces: only append parentSpaceId when an actual ID is provided. The server treats absence of the param as "top-level only," which matches the documented behavior of fetchSpaces({ parentSpaceId: null }).
- useSpaceList default state and resetUnspecified reset now use undefined instead of null, so the serializer never sees a "null means top-level" sentinel that needs special-casing.

Fixes #10

Authored-By: Jenova Marie <jenova-marie@pm.me>