### PR TITLE
fix(core): don't persist an account while access token and user are mismatched

### DIFF
--- a/packages/core/src/hooks/auth/useAccountSync.ts
+++ b/packages/core/src/hooks/auth/useAccountSync.ts
@@ -13,7 +13,7 @@ import {
   type AccountSummary,
   type AccountEntry,
 } from "../../store/slices/accountsSlice";
-import { selectRefreshToken, setRefreshToken } from "../../store/slices/authSlice";
+import { selectRefreshToken, setRefreshToken, selectAccessToken } from "../../store/slices/authSlice";
 import { selectUser } from "../../store/slices/userSlice";
 import { handleError } from "../../utils/handleError";
 import type { AccountStorage } from "../../interfaces/AccountStorage";
@@ -37,12 +37,25 @@ function extractExpFromJwt(jwt: string): number {
   }
 }
 
+// The access token's subject (the profile/user id it was minted for). Used to detect a transient
+// token/user desync before we persist an account entry.
+function extractSubFromJwt(jwt: string | null | undefined): string | null {
+  if (!jwt) return null;
+  try {
+    const payload = JSON.parse(base64UrlDecode(jwt.split(".")[1]));
+    return typeof payload.sub === "string" ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
 export default function useAccountSync(
   storage: AccountStorage,
   projectId: string
 ): void {
   const dispatch = useSublayDispatch();
   const refreshToken = useSublaySelector(selectRefreshToken);
+  const accessToken = useSublaySelector(selectAccessToken);
   const user = useSublaySelector(selectUser); // from userSlice (canonical)
   const accounts = useSublaySelector(selectAccounts);
   const activeAccountId = useSublaySelector(selectActiveAccountId);
@@ -88,6 +101,17 @@ export default function useAccountSync(
   useEffect(() => {
     if (!isReady || !refreshToken || !user?.id) return;
 
+    // Guard against a transient token/user desync. The accounts map keys by user.id but stores the
+    // CURRENT auth refresh token, so if these are momentarily mismatched (classically: an OAuth
+    // callback sets the new tokens via setTokens, but the new user only resolves a tick later, so
+    // this effect fires with the new token while `user` is still the previous account) we'd write
+    // the OLD user's entry against the NEW token — producing two account ids that share one refresh
+    // token (a corrupt map that breaks switching and sign-out). The access token is a JWT whose
+    // `sub` is the id it was minted for; only persist once it matches the current user. When they
+    // disagree we skip and wait — the effect re-runs when the user (or token) catches up.
+    const sub = extractSubFromJwt(accessToken);
+    if (sub && sub !== user.id) return;
+
     const summary: AccountSummary = {
       id: user.id,
       name: user.name ?? null,
@@ -106,7 +130,7 @@ export default function useAccountSync(
     if (user.id !== activeAccountId) {
       dispatch(setActiveAccount(user.id));
     }
-  }, [refreshToken, user, isReady]);
+  }, [refreshToken, accessToken, user, isReady]);
 
   // Phase C: Persist map on changes
   useEffect(() => {


### PR DESCRIPTION
## Problem

`useAccountSync` keys the persisted account map by `user.id` but stores the *current* `auth.refreshToken`. These can be momentarily out of sync — most notably during the OAuth callback (`useOAuthSignIn.handleOAuthCallback`), which sets the new tokens synchronously via `setTokens` but only resolves the new user a tick later (via `requestNewAccessTokenThunk`).

In that window the Phase B effect runs with the **new refresh token while `user` is still the previous account**, so it persists the previous user's entry (keyed by the old `user.id`) but paired with the *new* token.

The result is a corrupt account map: **two account ids that share a single refresh token**. Observed effects:

- account switching resolves to the same identity, and
- sign-out can't end the session (the multi-account "switch to remaining account" path keeps re-resolving the shared token).

## Fix

Only persist an account once the access token's `sub` matches the current `user.id`. The access token is a JWT minted for a specific id; when the token and user are transiently mismatched, the effect skips and waits — it re-runs when they catch up, so the correct entry is written a moment later.

`accessToken` is added to the Phase B dependency array so the effect re-evaluates when the token changes. No public API change — purely a correctness guard in the persistence effect.