### PR TITLE
feat(core): self-service account-deletion hooks

### DIFF
--- a/packages/core/src/hooks/auth/index.ts
+++ b/packages/core/src/hooks/auth/index.ts
@@ -8,4 +8,6 @@ export { default as useSignOutAll, type UseSignOutAllReturn } from './useSignOut
 export { default as useRequestPasswordReset, type RequestPasswordResetProps } from './useRequestPasswordReset';
 export { default as useSendVerificationEmail, type SendVerificationEmailProps } from './useSendVerificationEmail';
 export { default as useVerifyEmail, type VerifyEmailProps } from './useVerifyEmail';
+export { default as useRequestAccountDeletion } from './useRequestAccountDeletion';
+export { default as useConfirmAccountDeletion, type ConfirmAccountDeletionProps } from './useConfirmAccountDeletion';
 export { default as useOAuthIdentities, type OAuthIdentity, type UseOAuthIdentitiesReturn } from './useOAuthIdentities';

--- a/packages/core/src/hooks/auth/useConfirmAccountDeletion.ts
+++ b/packages/core/src/hooks/auth/useConfirmAccountDeletion.ts
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { useSublayDispatch } from "../../store/hooks";
+import { confirmAccountDeletionThunk } from "../../store/slices/authThunks";
+import useProject from "../projects/useProject";
+
+export interface ConfirmAccountDeletionProps {
+  /** The one-time code emailed by `useRequestAccountDeletion`. */
+  code: string;
+}
+
+/**
+ * Step 2 of self-service account deletion. Verifies the emailed code and then
+ * permanently deletes the signed-in user's account (same cascade as the
+ * admin/service delete). On success the local session is torn down like a
+ * sign-out — the deleted account is removed from the multi-account map and the
+ * SDK switches to a remaining account if there is one. This is immediate and
+ * cannot be undone.
+ */
+function useConfirmAccountDeletion(): (
+  props: ConfirmAccountDeletionProps
+) => Promise<void> {
+  const { projectId } = useProject();
+  const dispatch = useSublayDispatch();
+
+  const confirmAccountDeletion = useCallback(
+    async ({ code }: ConfirmAccountDeletionProps) => {
+      if (!projectId) {
+        throw new Error("No projectId available.");
+      }
+
+      if (!code?.trim()) {
+        throw new Error("Confirmation code is required.");
+      }
+
+      const result = await dispatch(
+        confirmAccountDeletionThunk({ projectId, code: code.trim() })
+      );
+
+      if (confirmAccountDeletionThunk.rejected.match(result)) {
+        throw new Error(result.payload as string);
+      }
+    },
+    [projectId, dispatch]
+  );
+
+  return confirmAccountDeletion;
+}
+
+export default useConfirmAccountDeletion;

--- a/packages/core/src/hooks/auth/useRequestAccountDeletion.ts
+++ b/packages/core/src/hooks/auth/useRequestAccountDeletion.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import axios from "../../config/axios";
+import useProject from "../projects/useProject";
+
+/**
+ * Step 1 of self-service account deletion. Emails the signed-in user a one-time
+ * confirmation code. Pass that code to `useConfirmAccountDeletion` to
+ * permanently delete the account.
+ *
+ * Requires the account to have an email on file — accounts without one (e.g.
+ * anonymous or foreign-id users) must be deleted server-side with a service key
+ * via the node SDK.
+ */
+function useRequestAccountDeletion(): () => Promise<{ success: boolean }> {
+  const { projectId } = useProject();
+
+  const requestAccountDeletion = useCallback(async () => {
+    if (!projectId) {
+      throw new Error("No projectId available.");
+    }
+
+    const response = await axios.post(
+      `/${projectId}/auth/request-account-deletion`,
+      {}
+    );
+
+    return response.data;
+  }, [projectId]);
+
+  return requestAccountDeletion;
+}
+
+export default useRequestAccountDeletion;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,8 @@ export {
   useRequestPasswordReset,
   useSendVerificationEmail,
   useVerifyEmail,
+  useRequestAccountDeletion,
+  useConfirmAccountDeletion,
   type UseAuthValues,
   type SignUpWithEmailAndPasswordProps,
   type SignInWithEmailAndPasswordProps,
@@ -64,6 +66,7 @@ export {
   type RequestPasswordResetProps,
   type SendVerificationEmailProps,
   type VerifyEmailProps,
+  type ConfirmAccountDeletionProps,
 } from "./hooks/auth";
 
 // -- authentication (accounts)

--- a/packages/core/src/store/slices/authThunks.ts
+++ b/packages/core/src/store/slices/authThunks.ts
@@ -139,6 +139,10 @@ const authService = {
   ) {
     await axios.post(`/${projectId}/auth/change-password`, data);
   },
+
+  async confirmAccountDeletion(projectId: string, code: string) {
+    await axios.post(`/${projectId}/auth/confirm-account-deletion`, { code });
+  },
 };
 
 // Async Thunks
@@ -291,6 +295,74 @@ export const signOutThunk = createAsyncThunk(
       return;
     } catch (error) {
       handleError(error, "Failed to log user out:");
+      return rejectWithValue(
+        error instanceof Error ? error.message : "Unknown error"
+      );
+    } finally {
+      dispatch(setAuthenticating(false));
+    }
+  }
+);
+
+export const confirmAccountDeletionThunk = createAsyncThunk(
+  "auth/confirmAccountDeletion",
+  async (
+    data: { projectId: string; code: string },
+    { dispatch, getState, rejectWithValue }
+  ) => {
+    const state = getState() as RootState;
+    const activeAccountId = state.sublay.accounts.activeAccountId;
+    const accounts = state.sublay.accounts.accounts;
+
+    try {
+      dispatch(setAuthenticating(true));
+
+      // Permanently delete the account on the server (verifies the emailed
+      // code). The user's tokens are destroyed as part of the cascade.
+      await authService.confirmAccountDeletion(data.projectId, data.code);
+
+      // Tear down the local session exactly like sign-out: drop the deleted
+      // account from the multi-account map, then either switch to a remaining
+      // account or fully reset. No server sign-out call — the session is
+      // already gone.
+      if (activeAccountId) {
+        dispatch(removeAccount(activeAccountId));
+      }
+
+      const remainingIds = Object.keys(accounts).filter(
+        (id) => id !== activeAccountId
+      );
+
+      if (remainingIds.length > 0) {
+        // Switch to the first remaining account
+        const nextId = remainingIds[0];
+        const nextAccount = accounts[nextId];
+
+        dispatch(resetAuth());
+        dispatch(clearUserInUserSlice());
+        dispatch(baseApi.util.resetApiState());
+        dispatch(
+          setTokens({
+            accessToken: null,
+            refreshToken: nextAccount.refreshToken,
+          })
+        );
+        dispatch(setInitialized(false));
+
+        await dispatch(
+          requestNewAccessTokenThunk({ projectId: data.projectId })
+        );
+        dispatch(setInitialized(true));
+      } else {
+        // No remaining accounts — standard teardown
+        dispatch(resetAuth());
+        dispatch(clearUserInUserSlice());
+        dispatch(baseApi.util.resetApiState());
+      }
+
+      return;
+    } catch (error) {
+      handleError(error, "Failed to delete account:");
       return rejectWithValue(
         error instanceof Error ? error.message : "Unknown error"
       );


### PR DESCRIPTION
## What

Adds two hooks so a signed-in end user can delete their **own** account (previously only admin/dashboard or service-key deletion existed):

- `useRequestAccountDeletion()` — emails the user a one-time confirmation code.
- `useConfirmAccountDeletion({ code })` — verifies the code and permanently deletes the account.

## How

- `useRequestAccountDeletion` is a thin authenticated POST (mirrors `useSendVerificationEmail`).
- `useConfirmAccountDeletion` dispatches a new `confirmAccountDeletionThunk` that, after the server deletes the account, tears down the local session **exactly like sign-out** — removes the deleted account from the multi-account map and switches to a remaining account if there is one (otherwise full reset). This avoids leaving a dead account in the persisted map that would try to refresh its invalid token on next launch.
- Exported from the core barrel; `@sublay/react-js` and `@sublay/react-native` pick them up via `export *`.

Part of a cross-repo feature (server endpoints + `@sublay/js` + docs). Type-checks clean; server side is covered by an integration test in the server repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)