### PR TITLE
feat(chat): otherMembers on ConversationPreview; forward memberIds in createGroup

### DIFF
--- a/packages/core/src/hooks/chat/conversations/useConversations.tsx
+++ b/packages/core/src/hooks/chat/conversations/useConversations.tsx
@@ -26,6 +26,10 @@ export interface UseConversationsValues {
   createGroup: (params: {
     name?: string;
     metadata?: Record<string, unknown>;
+    // Initial members to add at creation time (the server creates their member
+    // rows in the same transaction). The creator is added as admin automatically
+    // and is de-duplicated server-side if present here.
+    memberIds?: string[];
   }) => Promise<ConversationPreview>;
 }
 
@@ -133,6 +137,7 @@ function useConversations({
     async (params: {
       name?: string;
       metadata?: Record<string, unknown>;
+      memberIds?: string[];
     }): Promise<ConversationPreview> => {
       if (!projectId) throw new Error("No project ID");
 

--- a/packages/core/src/interfaces/models/Conversation.ts
+++ b/packages/core/src/interfaces/models/Conversation.ts
@@ -1,6 +1,7 @@
 import { File } from "./File";
 import { ChatMessage } from "./ChatMessage";
 import { ConversationMember } from "./ConversationMember";
+import { User } from "./User";
 
 export interface Conversation {
   id: string;
@@ -29,4 +30,10 @@ export interface ConversationPreview extends Conversation {
   unreadCount: number;
   // Truncated to 100 chars by the server for list performance
   lastMessage: ChatMessage | null;
+  // Up to 5 active members other than the requester, with public user fields
+  // (id, name, username, avatar). Populated for `direct` and `group`
+  // conversations only — a DM/group has no `name`, so the counterparty is how
+  // the list renders a title/avatar. Capped at 5 (use `memberCount` for the
+  // group total); empty array for `space` chats.
+  otherMembers?: Pick<User, "id" | "name" | "username" | "avatar">[];
 }


### PR DESCRIPTION
## What
- `ConversationPreview` now carries **`otherMembers`** — the (capped at 5) other members the list-conversations endpoint populates for direct/group conversations.
- `useConversations().createGroup` now forwards **`memberIds`**, so a group can be created with its initial members in a single request.

## Why
- DM/group rows need the counterparty to render a title/avatar (server-populated, no N+1).
- The server's create-group endpoint already creates members in one transaction; the SDK just wasn't passing them through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)