### PR TITLE
feat(reputation): wire space-scoped reputation into core hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/monorepo",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",
   "description": "Sublay: Build interactive apps with social features like comments, votes, feeds, user lists, notifications, and more.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/core",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/core/src/hooks/chat/conversations/useConversationMembers.tsx
+++ b/packages/core/src/hooks/chat/conversations/useConversationMembers.tsx
@@ -6,6 +6,13 @@ import { handleError } from "../../../utils/handleError";
 
 export interface UseConversationMembersProps {
   conversationId: string;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseConversationMembersValues {
@@ -23,6 +30,8 @@ export interface UseConversationMembersValues {
 
 function useConversationMembers({
   conversationId,
+  spaceReputationId,
+  spaceReputationDescendants,
 }: UseConversationMembersProps): UseConversationMembersValues {
   const { projectId } = useProject();
   const axios = useAxiosPrivate();
@@ -36,9 +45,12 @@ function useConversationMembers({
     const fetch = async () => {
       setLoading(true);
       try {
+        const params: Record<string, any> = { limit: 100 };
+        if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+        if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
         const response = await axios.get(
           `/${projectId}/chat/conversations/${conversationId}/members`,
-          { params: { limit: 100 } }
+          { params }
         );
         setMembers(response.data.data as ConversationMember[]);
       } catch (err) {
@@ -49,7 +61,7 @@ function useConversationMembers({
     };
 
     fetch();
-  }, [projectId, conversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectId, conversationId, spaceReputationId, spaceReputationDescendants]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addMember = useCallback(
     async ({ userId }: { userId: string }) => {

--- a/packages/core/src/hooks/chat/messages/useFetchManyChatMessages.tsx
+++ b/packages/core/src/hooks/chat/messages/useFetchManyChatMessages.tsx
@@ -26,6 +26,13 @@ export interface FetchManyChatMessagesProps {
   /** When `true`, the server populates the `files` field on each message. */
   includeFiles?: boolean;
   filters?: MessageFilters;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface FetchManyChatMessagesResponse {
@@ -65,6 +72,8 @@ function useFetchManyChatMessages(): (
         sort,
         includeFiles,
         filters,
+        spaceReputationId,
+        spaceReputationDescendants,
       } = props;
 
       if (!projectId) throw new Error("No project specified");
@@ -77,6 +86,8 @@ function useFetchManyChatMessages(): (
       if (after) params.after = after;
       if (includeFiles) params.include = "files";
       if (filters) params.filters = filters;
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<FetchManyChatMessagesResponse>(
         `/${projectId}/chat/conversations/${conversationId}/messages`,

--- a/packages/core/src/hooks/chat/messages/useFetchManyChatMessagesWrapper.tsx
+++ b/packages/core/src/hooks/chat/messages/useFetchManyChatMessagesWrapper.tsx
@@ -20,6 +20,13 @@ export interface UseFetchManyChatMessagesWrapperProps {
   /** When `true`, the server populates the `files` field on each message. */
   includeFiles?: boolean;
   filters?: MessageFilters;
+  /**
+   * Opt into per-row `spaceReputation` on embedded message authors. Accepted
+   * forms: a space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyChatMessagesWrapperValues {
@@ -48,6 +55,8 @@ function useFetchManyChatMessagesWrapper(
     sort = "desc",
     includeFiles,
     filters,
+    spaceReputationId,
+    spaceReputationDescendants,
   } = props;
 
   const fetchMany = useFetchManyChatMessages();
@@ -87,6 +96,8 @@ function useFetchManyChatMessagesWrapper(
         sort,
         includeFiles,
         filters,
+        spaceReputationId,
+        spaceReputationDescendants,
       });
       setMessages(res.messages);
       hasMoreRef.current = res.hasMore;
@@ -99,7 +110,7 @@ function useFetchManyChatMessagesWrapper(
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, advanceCursor]);
+  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, spaceReputationId, spaceReputationDescendants, advanceCursor]);
 
   const loadMore = useCallback(async () => {
     if (loadingRef.current || !hasMoreRef.current || !cursorRef.current) return;
@@ -113,6 +124,8 @@ function useFetchManyChatMessagesWrapper(
         sort,
         includeFiles,
         filters,
+        spaceReputationId,
+        spaceReputationDescendants,
         ...(sort === "asc"
           ? { after: cursorRef.current }
           : { before: cursorRef.current }),
@@ -128,7 +141,7 @@ function useFetchManyChatMessagesWrapper(
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, advanceCursor]);
+  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, spaceReputationId, spaceReputationDescendants, advanceCursor]);
 
   useEffect(() => {
     refetch();

--- a/packages/core/src/hooks/chat/messages/useSendMessage.tsx
+++ b/packages/core/src/hooks/chat/messages/useSendMessage.tsx
@@ -22,6 +22,17 @@ export interface SendMessageParams {
   quotedMessageId?: string | null;
   parentMessageId?: string | null;
   files?: File[];
+  /**
+   * Opt into `spaceReputation` on the enriched sender returned in the response.
+   * Accepted forms: a space `<uuid>`, `"none"`, or `"context"`. Sent as a query
+   * param so it works for both the JSON and multipart request shapes.
+   */
+  spaceReputationId?: string;
+  /**
+   * Include reputation accrued in descendant spaces. Only honored when
+   * `spaceReputationId` is an explicit `<uuid>`.
+   */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseSendMessageProps {
@@ -49,9 +60,17 @@ function useSendMessage({
       quotedMessageId,
       parentMessageId,
       files,
+      spaceReputationId,
+      spaceReputationDescendants,
     }: SendMessageParams): Promise<ChatMessage> => {
       if (!projectId) throw new Error("No projectId available.");
       if (!conversationId) throw new Error("No conversationId provided.");
+
+      const reputationParams: Record<string, any> = {};
+      if (spaceReputationId !== undefined)
+        reputationParams.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined)
+        reputationParams.spaceReputationDescendants = spaceReputationDescendants;
 
       const localId = crypto.randomUUID();
       const now = new Date();
@@ -104,7 +123,7 @@ function useSendMessage({
           response = await axios.post(
             `/${projectId}/chat/conversations/${conversationId}/messages`,
             formData,
-            { headers: { "Content-Type": "multipart/form-data" } }
+            { headers: { "Content-Type": "multipart/form-data" }, params: reputationParams }
           );
         } else {
           // JSON body for text/gif-only messages
@@ -118,7 +137,8 @@ function useSendMessage({
               ...(metadata !== undefined && { metadata }),
               ...(quotedMessageId !== undefined && { quotedMessageId }),
               ...(parentMessageId !== undefined && { parentMessageId }),
-            }
+            },
+            { params: reputationParams }
           );
         }
 

--- a/packages/core/src/hooks/comments/useEntityComments.tsx
+++ b/packages/core/src/hooks/comments/useEntityComments.tsx
@@ -13,6 +13,13 @@ export interface UseEntityCommentsProps {
   limit?: number;
   defaultSortBy?: CommentsSortByOptions;
   include?: CommentIncludeParam;
+  /**
+   * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
+   * forms: a space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseEntityCommentsValues {
@@ -35,7 +42,14 @@ export interface UseEntityCommentsValues {
 function useEntityComments(
   props: UseEntityCommentsProps
 ): UseEntityCommentsValues {
-  const { entityId, limit = 10, defaultSortBy = "new", include } = props;
+  const {
+    entityId,
+    limit = 10,
+    defaultSortBy = "new",
+    include,
+    spaceReputationId,
+    spaceReputationDescendants,
+  } = props;
 
   const fetchManyComments = useFetchManyComments();
 
@@ -117,6 +131,8 @@ function useEntityComments(
         sortBy,
         limit,
         include,
+        spaceReputationId,
+        spaceReputationDescendants,
       });
 
       if (response) {
@@ -131,7 +147,7 @@ function useEntityComments(
       loading.current = false;
       setLoadingState(false);
     }
-  }, [fetchManyComments, limit, sortBy, entityId]);
+  }, [fetchManyComments, limit, sortBy, entityId, include, spaceReputationId, spaceReputationDescendants]);
 
   const loadMore = () => {
     if (loading.current || !hasMore.current) return;
@@ -160,6 +176,8 @@ function useEntityComments(
           page,
           sortBy,
           limit,
+          spaceReputationId,
+          spaceReputationDescendants,
         });
 
         if (response) {

--- a/packages/core/src/hooks/comments/useFetchComment.tsx
+++ b/packages/core/src/hooks/comments/useFetchComment.tsx
@@ -6,13 +6,20 @@ import axios from "../../config/axios";
 export interface FetchCommentProps {
   commentId: string;
   include?: CommentIncludeParam;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchComment(): (props: FetchCommentProps) => Promise<{ comment: Comment }> {
   const { projectId } = useProject();
 
   const fetchComment = useCallback(
-    async ({ commentId, include }: FetchCommentProps) => {
+    async ({ commentId, include, spaceReputationId, spaceReputationDescendants }: FetchCommentProps) => {
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -26,6 +33,8 @@ function useFetchComment(): (props: FetchCommentProps) => Promise<{ comment: Com
       if (include) {
         params.include = Array.isArray(include) ? include.join(',') : include;
       }
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/comments/${commentId}`, {
         params,

--- a/packages/core/src/hooks/comments/useFetchManyComments.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyComments.tsx
@@ -14,6 +14,13 @@ export interface FetchManyCommentsProps {
   limit?: number;
   include?: CommentIncludeParam;
   sourceId?: string | null | undefined;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<PaginatedResponse<Comment>> {
@@ -31,6 +38,8 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
         limit,
         include,
         sourceId,
+        spaceReputationId,
+        spaceReputationDescendants,
       } = props;
 
       if (page === 0) {
@@ -55,6 +64,8 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
       if (userId) params.userId = userId;
       if (parentId) params.parentId = parentId;
       if (sourceId) params.sourceId = sourceId;
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       if (include) {
         params.include = Array.isArray(include) ? include.join(',') : include;

--- a/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
@@ -12,6 +12,13 @@ export interface UseFetchManyCommentsWrapperProps {
   limit?: number;
   include?: CommentIncludeParam;
   defaultSortBy?: CommentsSortByOptions;
+  /**
+   * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
+   * forms: a space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyCommentsWrapperValues {
@@ -34,6 +41,8 @@ function useFetchManyCommentsWrapper(
     limit = 10,
     defaultSortBy = "new",
     include,
+    spaceReputationId,
+    spaceReputationDescendants,
   } = props;
   const fetchManyComments = useFetchManyComments();
 
@@ -70,6 +79,8 @@ function useFetchManyCommentsWrapper(
         sortBy,
         limit,
         include,
+        spaceReputationId,
+        spaceReputationDescendants,
       });
 
       if (response) {
@@ -93,6 +104,8 @@ function useFetchManyCommentsWrapper(
     parentId,
     sourceId,
     include,
+    spaceReputationId,
+    spaceReputationDescendants,
   ]);
 
   const loadMore = () => {
@@ -121,6 +134,8 @@ function useFetchManyCommentsWrapper(
           sortBy,
           limit,
           include,
+          spaceReputationId,
+          spaceReputationDescendants,
         });
 
         if (response) {
@@ -151,6 +166,8 @@ function useFetchManyCommentsWrapper(
     sortBy,
     limit,
     include,
+    spaceReputationId,
+    spaceReputationDescendants,
   ]);
 
   return {

--- a/packages/core/src/hooks/entities/useFetchEntity.tsx
+++ b/packages/core/src/hooks/entities/useFetchEntity.tsx
@@ -6,6 +6,13 @@ import useAxiosPrivate from "../../config/useAxiosPrivate";
 export interface FetchEntityProps {
   entityId: string;
   include?: EntityIncludeParam;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
@@ -13,7 +20,7 @@ function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
   const { projectId } = useProject();
 
   const fetchEntity = useCallback(
-    async ({ entityId, include }: FetchEntityProps) => {
+    async ({ entityId, include, spaceReputationId, spaceReputationDescendants }: FetchEntityProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -22,10 +29,15 @@ function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
         throw new Error("Please pass an entityId");
       }
 
+      const params: Record<string, any> = {
+        include: Array.isArray(include) ? include.join(",") : include,
+      };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined)
+        params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get(`/${projectId}/entities/${entityId}`, {
-        params: {
-          include: Array.isArray(include) ? include.join(",") : include,
-        },
+        params,
       });
 
       return response.data as Entity;

--- a/packages/core/src/hooks/entities/useFetchManyEntities.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntities.tsx
@@ -65,6 +65,13 @@ interface FetchManyEntitiesParams {
   locationFilters?: LocationFilters | null;
   metadataFilters?: MetadataFilters | null;
   include?: EntityIncludeParam;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchManyEntities(): (params?: FetchManyEntitiesParams) => Promise<PaginatedResponse<Entity>> {
@@ -90,6 +97,8 @@ function useFetchManyEntities(): (params?: FetchManyEntitiesParams) => Promise<P
       if (params?.spaceId) queryParams.spaceId = params.spaceId;
       if (params?.userId) queryParams.userId = params.userId;
       if (params?.followedOnly !== undefined) queryParams.followedOnly = params.followedOnly;
+      if (params?.spaceReputationId !== undefined) queryParams.spaceReputationId = params.spaceReputationId;
+      if (params?.spaceReputationDescendants !== undefined) queryParams.spaceReputationDescendants = params.spaceReputationDescendants;
 
       if (params?.include) {
         queryParams.include = Array.isArray(params.include)

--- a/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
@@ -29,6 +29,13 @@ export interface UseFetchManyEntitiesWrapperProps {
   attachmentsFilters?: AttachmentsFilters | null;
   locationFilters?: LocationFilters | null;
   metadataFilters?: MetadataFilters | null;
+  /**
+   * Opt into per-row `spaceReputation` on embedded authors. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyEntitiesWrapperValues {
@@ -67,6 +74,8 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
+    spaceReputationId,
+    spaceReputationDescendants,
   } = props;
   const fetchManyEntities = useFetchManyEntities();
 
@@ -112,6 +121,8 @@ function useFetchManyEntitiesWrapper(
         attachmentsFilters,
         locationFilters,
         metadataFilters,
+        spaceReputationId,
+        spaceReputationDescendants,
       });
 
       if (response) {
@@ -145,6 +156,8 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
+    spaceReputationId,
+    spaceReputationDescendants,
   ]);
 
   const loadMore = () => {
@@ -183,6 +196,8 @@ function useFetchManyEntitiesWrapper(
           attachmentsFilters,
           locationFilters,
           metadataFilters,
+          spaceReputationId,
+          spaceReputationDescendants,
         });
 
         if (response) {
@@ -223,6 +238,8 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
+    spaceReputationId,
+    spaceReputationDescendants,
   ]);
 
   return {

--- a/packages/core/src/hooks/entity-lists/useEntityList.ts
+++ b/packages/core/src/hooks/entity-lists/useEntityList.ts
@@ -175,6 +175,8 @@ function useEntityList({
           spaceId: configWithDefaults.spaceId,
           limit: configWithDefaults.limit,
           include: configWithDefaults.include,
+          spaceReputationId: configWithDefaults.spaceReputationId,
+          spaceReputationDescendants: configWithDefaults.spaceReputationDescendants,
         };
 
         // Build final filters by taking current state and applying new filters
@@ -259,6 +261,8 @@ function useEntityList({
             sourceId: currentConfig.sourceId,
             spaceId: currentConfig.spaceId,
             include: currentConfig.include,
+            spaceReputationId: currentConfig.spaceReputationId,
+            spaceReputationDescendants: currentConfig.spaceReputationDescendants,
           });
         } catch (err) {
           console.error(
@@ -330,6 +334,8 @@ function useEntityList({
         sourceId: config.sourceId,
         spaceId: config.spaceId,
         include: config.include,
+        spaceReputationId: config.spaceReputationId,
+        spaceReputationDescendants: config.spaceReputationDescendants,
       });
     } catch (err) {
       console.error(

--- a/packages/core/src/hooks/entity-lists/useEntityListActions.ts
+++ b/packages/core/src/hooks/entity-lists/useEntityListActions.ts
@@ -50,6 +50,8 @@ interface FetchEntitiesOptions {
   spaceId?: string | null;
   limit: number;
   include?: EntityIncludeParam | null;
+  spaceReputationId?: string | null;
+  spaceReputationDescendants?: boolean | null;
 }
 
 interface CreateEntityOptions {
@@ -131,6 +133,8 @@ export function useEntityListActions(): UseEntityListActionsValues {
           contentFilters: options.contentFilters,
           attachmentsFilters: options.attachmentsFilters,
           include: options.include,
+          spaceReputationId: options.spaceReputationId,
+          spaceReputationDescendants: options.spaceReputationDescendants,
         }).unwrap();
 
         if (result) {

--- a/packages/core/src/hooks/reactions/useFetchCommentReactions.tsx
+++ b/packages/core/src/hooks/reactions/useFetchCommentReactions.tsx
@@ -10,6 +10,13 @@ export interface FetchCommentReactionsProps {
   limit?: number;
   reactionType?: ReactionType;
   sortDir?: "asc" | "desc";
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Promise<PaginatedResponse<Reaction>> {
@@ -17,7 +24,7 @@ function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Prom
 
   const fetchCommentReactions = useCallback(
     async (props: FetchCommentReactionsProps): Promise<PaginatedResponse<Reaction>> => {
-      const { commentId, page, limit = 20, reactionType, sortDir = "desc" } = props;
+      const { commentId, page, limit = 20, reactionType, sortDir = "desc", spaceReputationId, spaceReputationDescendants } = props;
 
       if (page === 0) {
         throw new Error("Can't fetch reactions with page 0");
@@ -44,6 +51,8 @@ function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Prom
       if (reactionType) {
         params.reactionType = reactionType;
       }
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<PaginatedResponse<Reaction>>(
         `/${projectId}/comments/${commentId}/reactions`,

--- a/packages/core/src/hooks/reactions/useFetchEntityReactions.tsx
+++ b/packages/core/src/hooks/reactions/useFetchEntityReactions.tsx
@@ -10,6 +10,13 @@ export interface FetchEntityReactionsProps {
   limit?: number;
   reactionType?: ReactionType;
   sortDir?: "asc" | "desc";
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promise<PaginatedResponse<Reaction>> {
@@ -17,7 +24,7 @@ function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promis
 
   const fetchEntityReactions = useCallback(
     async (props: FetchEntityReactionsProps): Promise<PaginatedResponse<Reaction>> => {
-      const { entityId, page, limit = 20, reactionType, sortDir = "desc" } = props;
+      const { entityId, page, limit = 20, reactionType, sortDir = "desc", spaceReputationId, spaceReputationDescendants } = props;
 
       if (page === 0) {
         throw new Error("Can't fetch reactions with page 0");
@@ -44,6 +51,8 @@ function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promis
       if (reactionType) {
         params.reactionType = reactionType;
       }
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<PaginatedResponse<Reaction>>(
         `/${projectId}/entities/${entityId}/reactions`,

--- a/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
+++ b/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
@@ -8,6 +8,14 @@ export interface FetchConnectionsByUserIdParams {
   userId: string;
   page?: number;
   limit?: number;
+  /**
+   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
+   * by-user-id graph read has no per-row space context.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) => Promise<PaginatedResponse<EstablishedConnection>> {
@@ -17,7 +25,7 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
     async (
       props: FetchConnectionsByUserIdParams
     ): Promise<PaginatedResponse<EstablishedConnection>> => {
-      const { userId, page = 1, limit = 20 } = props;
+      const { userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants } = props;
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -26,13 +34,14 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
         throw new Error("No user ID was provided");
       }
 
+      const params: Record<string, any> = { page, limit };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get<PaginatedResponse<EstablishedConnection>>(
         `/users/${userId}/connections`,
         {
-          params: {
-            page,
-            limit,
-          },
+          params,
         }
       );
 

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
@@ -14,13 +14,21 @@ export interface FetchFollowersByUserIdParams {
   userId: string;
   page?: number;
   limit?: number;
+  /**
+   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
+   * by-user-id graph read has no per-row space context.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => Promise<PaginatedResponse<FollowerWithFollowInfo>> {
   const { projectId } = useProject();
 
   const fetchFollowersByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20 }: FetchFollowersByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants }: FetchFollowersByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -29,9 +37,13 @@ function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => 
         throw new Error("No projectId available.");
       }
 
+      const params: Record<string, any> = { page, limit };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get<PaginatedResponse<FollowerWithFollowInfo>>(
         `/${projectId}/users/${userId}/followers`,
-        { params: { page, limit } }
+        { params }
       );
 
       return response.data;

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
@@ -14,13 +14,21 @@ export interface FetchFollowingByUserIdParams {
   userId: string;
   page?: number;
   limit?: number;
+  /**
+   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
+   * by-user-id graph read has no per-row space context.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => Promise<PaginatedResponse<FollowingWithFollowInfo>> {
   const { projectId } = useProject();
 
   const fetchFollowingByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20 }: FetchFollowingByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants }: FetchFollowingByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -29,13 +37,14 @@ function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => 
         throw new Error("No projectId available.");
       }
 
+      const params: Record<string, any> = { page, limit };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get<PaginatedResponse<FollowingWithFollowInfo>>(
         `/${projectId}/users/${userId}/following`,
         {
-          params: {
-            page,
-            limit,
-          },
+          params,
         }
       );
 

--- a/packages/core/src/hooks/reports/useFetchModeratedReports.tsx
+++ b/packages/core/src/hooks/reports/useFetchModeratedReports.tsx
@@ -13,6 +13,13 @@ export interface FetchModeratedReportsParams {
   sortBy?: "new" | "old";
   page?: number;
   limit?: number;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface ReportUserReport {
@@ -75,14 +82,20 @@ function useFetchModeratedReports(): (params: FetchModeratedReportsParams) => Pr
       sortBy,
       page,
       limit,
+      spaceReputationId,
+      spaceReputationDescendants,
     }: FetchModeratedReportsParams) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
 
+      const params: Record<string, any> = { spaceId, targetType, status, sortBy, page, limit };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get<PaginatedResponse<Report>>(
         `/${projectId}/reports/moderated`,
-        { params: { spaceId, targetType, status, sortBy, page, limit } }
+        { params }
       );
 
       return response.data;

--- a/packages/core/src/hooks/search/useAskContent.ts
+++ b/packages/core/src/hooks/search/useAskContent.ts
@@ -11,6 +11,14 @@ export interface UseAskContentProps {
   spaceId?: string;
   conversationId?: string;
   limit?: number;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`. Sent as a query param (the server
+   * reads it from the query string, not the request body).
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseAskContentReturn {
@@ -90,7 +98,7 @@ export default function useAskContent(): UseAskContentReturn {
   }, []);
 
   const ask = useCallback(
-    ({ query, sourceTypes, spaceId, conversationId, limit }: UseAskContentProps) => {
+    ({ query, sourceTypes, spaceId, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseAskContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
@@ -123,9 +131,20 @@ export default function useAskContent(): UseAskContentReturn {
       }
 
       // Run async without blocking the render cycle — errors are surfaced via state
+      // spaceReputation opt-in is read from the query string by the server,
+      // not the request body — append it to the URL.
+      const queryString = (() => {
+        const sp = new URLSearchParams();
+        if (spaceReputationId !== undefined) sp.set("spaceReputationId", spaceReputationId);
+        if (spaceReputationDescendants !== undefined)
+          sp.set("spaceReputationDescendants", String(spaceReputationDescendants));
+        const s = sp.toString();
+        return s ? `?${s}` : "";
+      })();
+
       (async () => {
         try {
-          const response = await fetch(`${BASE_URL}/${projectId}/search/ask`, {
+          const response = await fetch(`${BASE_URL}/${projectId}/search/ask${queryString}`, {
             method: "POST",
             headers,
             body,

--- a/packages/core/src/hooks/search/useSearchContent.ts
+++ b/packages/core/src/hooks/search/useSearchContent.ts
@@ -18,6 +18,14 @@ export interface UseSearchContentProps {
   spaceId?: string;
   conversationId?: string;
   limit?: number;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`. Sent as a query param (the server
+   * reads it from the query string, not the request body).
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 export interface UseSearchContentReturn {
@@ -37,16 +45,20 @@ export default function useSearchContent(): UseSearchContentReturn {
   const [error, setError] = useState<string | null>(null);
 
   const search = useCallback(
-    async ({ query, sourceTypes, spaceId, conversationId, limit }: UseSearchContentProps) => {
+    async ({ query, sourceTypes, spaceId, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseSearchContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
       setLoading(true);
       setError(null);
       try {
+        const params: Record<string, any> = {};
+        if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+        if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
         const response = await axios.post<ContentSearchResult[]>(
           `/${projectId}/search/content`,
-          { query, sourceTypes, spaceId, conversationId, limit }
+          { query, sourceTypes, spaceId, conversationId, limit },
+          { params }
         );
         setResults(response.data);
       } catch (err) {

--- a/packages/core/src/hooks/spaces/useFetchSpaceMembers.tsx
+++ b/packages/core/src/hooks/spaces/useFetchSpaceMembers.tsx
@@ -13,6 +13,13 @@ export interface FetchSpaceMembersProps {
   limit?: number;
   role?: SpaceMemberRole;
   status?: SpaceMemberStatus;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<SpaceMembersResponse> {
@@ -20,7 +27,7 @@ function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<Spac
   const axios = useAxiosPrivate();
 
   const fetchSpaceMembers = useCallback(
-    async ({ spaceId, page, limit, role, status }: FetchSpaceMembersProps) => {
+    async ({ spaceId, page, limit, role, status, spaceReputationId, spaceReputationDescendants }: FetchSpaceMembersProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -29,9 +36,13 @@ function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<Spac
         throw new Error("Please pass a spaceId");
       }
 
+      const params: Record<string, any> = { page, limit, role, status };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get<SpaceMembersResponse>(
         `/${projectId}/spaces/${spaceId}/members`,
-        { params: { page, limit, role, status } }
+        { params }
       );
 
       return response.data;

--- a/packages/core/src/hooks/spaces/useFetchSpaceTeam.tsx
+++ b/packages/core/src/hooks/spaces/useFetchSpaceTeam.tsx
@@ -5,6 +5,13 @@ import useAxiosPrivate from "../../config/useAxiosPrivate";
 
 export interface FetchSpaceTeamProps {
   spaceId: string;
+  /**
+   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 // Fetches all admins and moderators of a space (no pagination)
@@ -13,7 +20,7 @@ function useFetchSpaceTeam(): (props: FetchSpaceTeamProps) => Promise<SpaceTeamR
   const axios = useAxiosPrivate();
 
   const fetchSpaceTeam = useCallback(
-    async ({ spaceId }: FetchSpaceTeamProps) => {
+    async ({ spaceId, spaceReputationId, spaceReputationDescendants }: FetchSpaceTeamProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -24,7 +31,11 @@ function useFetchSpaceTeam(): (props: FetchSpaceTeamProps) => Promise<SpaceTeamR
 
       const url = `/${projectId}/spaces/${spaceId}/team`;
 
-      const response = await axios.get<SpaceTeamResponse>(url);
+      const params: Record<string, any> = {};
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
+      const response = await axios.get<SpaceTeamResponse>(url, { params });
 
       return response.data;
     },

--- a/packages/core/src/hooks/users/useFetchUser.tsx
+++ b/packages/core/src/hooks/users/useFetchUser.tsx
@@ -7,6 +7,14 @@ import { User, UserIncludeParam } from "../../interfaces/models/User";
 export interface FetchUserProps {
   userId: string;
   include?: UserIncludeParam;
+  /**
+   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
+   * bare user lookup — there is no row context to derive a space from.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUser(): (props: FetchUserProps) => Promise<User> {
@@ -16,6 +24,8 @@ function useFetchUser(): (props: FetchUserProps) => Promise<User> {
     async ({
       userId,
       include,
+      spaceReputationId,
+      spaceReputationDescendants,
     }: FetchUserProps) => {
       if (!projectId) {
         throw new Error("No project specified");
@@ -25,10 +35,14 @@ function useFetchUser(): (props: FetchUserProps) => Promise<User> {
         throw new Error("Please specify a user ID");
       }
 
+      const params: Record<string, any> = {
+        include: Array.isArray(include) ? include.join(",") : include,
+      };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get(`/${projectId}/users/${userId}`, {
-        params: {
-          include: Array.isArray(include) ? include.join(",") : include,
-        },
+        params,
       });
 
       return response.data as User;

--- a/packages/core/src/hooks/users/useFetchUserByForeignId.tsx
+++ b/packages/core/src/hooks/users/useFetchUserByForeignId.tsx
@@ -7,6 +7,14 @@ import { User, UserIncludeParam } from "../../interfaces/models/User";
 export interface FetchUserByForeignIdProps {
   foreignId: string;
   include?: UserIncludeParam;
+  /**
+   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
+   * bare user lookup — there is no row context to derive a space from.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promise<User> {
@@ -16,6 +24,8 @@ function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promis
     async ({
       foreignId,
       include,
+      spaceReputationId,
+      spaceReputationDescendants,
     }: FetchUserByForeignIdProps) => {
       if (!projectId) {
         throw new Error("No project specified");
@@ -25,11 +35,15 @@ function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promis
         throw new Error("Please specify a foreign ID");
       }
 
+      const params: Record<string, any> = {
+        foreignId,
+        include: Array.isArray(include) ? include.join(",") : include,
+      };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get(`/${projectId}/users/by-foreign-id`, {
-        params: {
-          foreignId,
-          include: Array.isArray(include) ? include.join(",") : include,
-        },
+        params,
       });
 
       return response.data as User;

--- a/packages/core/src/hooks/users/useFetchUserByUsername.tsx
+++ b/packages/core/src/hooks/users/useFetchUserByUsername.tsx
@@ -7,6 +7,14 @@ import { User, UserIncludeParam } from "../../interfaces/models/User";
 export interface FetchUserByUsernameProps {
   username: string;
   include?: UserIncludeParam;
+  /**
+   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
+   * bare user lookup — there is no row context to derive a space from.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<User> {
@@ -16,6 +24,8 @@ function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<
     async ({
       username,
       include,
+      spaceReputationId,
+      spaceReputationDescendants,
     }: FetchUserByUsernameProps) => {
       if (!projectId) {
         throw new Error("No project specified");
@@ -25,11 +35,15 @@ function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<
         throw new Error("Please specify a username");
       }
 
+      const params: Record<string, any> = {
+        username,
+        include: Array.isArray(include) ? include.join(",") : include,
+      };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get(`/${projectId}/users/by-username`, {
-        params: {
-          username,
-          include: Array.isArray(include) ? include.join(",") : include,
-        },
+        params,
       });
 
       return response.data as User;

--- a/packages/core/src/hooks/users/useFetchUserSuggestions.tsx
+++ b/packages/core/src/hooks/users/useFetchUserSuggestions.tsx
@@ -5,6 +5,14 @@ import { User } from "../../interfaces/models/User";
 
 export interface FetchUserSuggestionsProps {
   query: string;
+  /**
+   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
+   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
+   * bare user lookup — there is no row context to derive a space from.
+   */
+  spaceReputationId?: string;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserSuggestions(): (props: FetchUserSuggestionsProps) => Promise<User[]> {
@@ -12,15 +20,17 @@ function useFetchUserSuggestions(): (props: FetchUserSuggestionsProps) => Promis
   const { projectId } = useProject();
 
   const fetchUserSuggestions = useCallback(
-    async ({ query }: FetchUserSuggestionsProps) => {
+    async ({ query, spaceReputationId, spaceReputationDescendants }: FetchUserSuggestionsProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
 
+      const params: Record<string, any> = { query };
+      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
+      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+
       const response = await axios.get(`/${projectId}/users/suggestions`, {
-        params: {
-          query,
-        },
+        params,
       });
 
       return response.data as User[];

--- a/packages/core/src/interfaces/models/User.ts
+++ b/packages/core/src/interfaces/models/User.ts
@@ -23,6 +23,7 @@ export type UserFull = {
   metadata: Record<string, any>; // JSON object that could contain any other data about the user which is relevant to the project. Limited to 10KB size.
   secureMetadata: Record<string, any>; // Same as metadata only it is excluded when user is added to entity and comment data
   reputation: number; // Automatically managed by sublay based on usr activity
+  spaceReputation?: number; // Per-space reputation, present only when a request opts in via `spaceReputationId`
   isVerified: boolean; // Whether the user is verified
   isActive: boolean; // Whether the user account is active
   lastActive: Date; // Timestamp for last activity

--- a/packages/core/src/store/api/entityListsApi.ts
+++ b/packages/core/src/store/api/entityListsApi.ts
@@ -97,6 +97,8 @@ interface FetchEntitiesParams {
   sourceId?: string | null;
   spaceId?: string | null;
   include?: EntityIncludeParam | null;
+  spaceReputationId?: string | null;
+  spaceReputationDescendants?: boolean | null;
 }
 
 interface CreateEntityParams {
@@ -160,7 +162,9 @@ export const entityListsApi = baseApi.injectEndpoints({
         titleFilters,
         contentFilters,
         attachmentsFilters,
-        include
+        include,
+        spaceReputationId,
+        spaceReputationDescendants
       }) => {
         if (!sortBy) {
           throw new Error("sortBy is required for fetching entities");
@@ -179,6 +183,9 @@ export const entityListsApi = baseApi.injectEndpoints({
             userId,
             sourceId,
             spaceId,
+            spaceReputationId,
+            spaceReputationDescendants:
+              spaceReputationDescendants === null ? undefined : spaceReputationDescendants,
             sortBy,
             sortByReaction,
             sortDir,

--- a/packages/core/src/store/slices/entityListsSlice.ts
+++ b/packages/core/src/store/slices/entityListsSlice.ts
@@ -29,6 +29,8 @@ export interface EntityListState {
   spaceId: string | null;
   limit: number;
   include: EntityIncludeParam | null;
+  spaceReputationId: string | null;
+  spaceReputationDescendants: boolean | null;
 
   // Filter/sort state (user-controlled filters only)
   sortBy: EntityListSortByOptions;
@@ -65,6 +67,8 @@ const createDefaultEntityListState = (): EntityListState => ({
   spaceId: null,
   limit: 10,
   include: null,
+  spaceReputationId: null,
+  spaceReputationDescendants: null,
 
   // Default filters (user-controlled only)
   sortBy: "hot",
@@ -115,6 +119,13 @@ export interface EntityListConfig {
   spaceId?: string | null;
   limit?: number;
   include?: EntityIncludeParam | null;
+  /**
+   * Opt into per-row `spaceReputation` on embedded authors. Accepted forms: a
+   * space `<uuid>`, `"none"`, or `"context"`.
+   */
+  spaceReputationId?: string | null;
+  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  spaceReputationDescendants?: boolean | null;
 }
 
 // Options for entity list operations
@@ -243,6 +254,12 @@ export const entityListsSlice = createSlice({
         }
         if (config.include !== undefined) {
           list.include = config.include;
+        }
+        if (config.spaceReputationId !== undefined) {
+          list.spaceReputationId = config.spaceReputationId;
+        }
+        if (config.spaceReputationDescendants !== undefined) {
+          list.spaceReputationDescendants = config.spaceReputationDescendants;
         }
       }
 
@@ -532,6 +549,8 @@ export const selectEntityListConfig = createSelector(
     spaceId: string | null;
     limit: number;
     include: EntityIncludeParam | null;
+    spaceReputationId: string | null;
+    spaceReputationDescendants: boolean | null;
   } | null => {
     if (!entityList) return null;
 
@@ -540,6 +559,8 @@ export const selectEntityListConfig = createSelector(
       spaceId: entityList.spaceId,
       limit: entityList.limit,
       include: entityList.include,
+      spaceReputationId: entityList.spaceReputationId,
+      spaceReputationDescendants: entityList.spaceReputationDescendants,
     };
   }
 );

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/expo",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/react-js/package.json
+++ b/packages/react-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/react-js",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/react-native",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",


### PR DESCRIPTION
Mirrors the final server read contract for space-scoped reputation into `@sublay/core` (and the packages that re-export it). Additive, non-breaking.

## What changed
- **User type**: `spaceReputation?: number` on `UserFull` (`packages/core/src/interfaces/models/User.ts`).
- **Direct-axios context hooks**: `useFetchEntity`, `useFetchManyEntities`, `useFetchComment`, `useFetchManyComments`, `useFetchEntityReactions`, `useFetchCommentReactions`, `useFetchSpaceMembers`, `useFetchSpaceTeam`, `useFetchManyChatMessages`, `useConversationMembers`, `useSearchContent`, `useAskContent`, `useFetchModeratedReports`, plus the `useSendMessage` mutation (params forwarded on the POST). Context hooks accept `<uuid> | "none" | "context"`.
- **User-direct hooks** (`<uuid> | "none"` only; `"context"` rejected server-side): `useFetchUser`, `useFetchUserByForeignId`, `useFetchUserByUsername`, `useFetchUserSuggestions`, and the `*ByUserId` relationship reads.
- **Stateful feeds**: the RTK entity-list feed threaded end-to-end (`useEntityList` -> `useEntityListActions` -> `entityListsApi`/`buildQueryParams` + the `EntityListConfig` slice), nullable mirroring `spaceId`; and the entity-comments feed (`useEntityComments`).

## Out of scope / not wired
Plain self-relative `useFetchConnections/Followers/Following`, `useSearchUsers`, `useSearchSpaces` — the server does not enrich those routes. No new hooks added for chat single-message/list-reactions (no such hooks exist).

## Verification
`tsc --noEmit` clean across `packages/core`. The `chore(release)` commit bumps all packages 7.2.0 -> 7.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)