### PR TITLE
fix(interfaces): type GifData altText/aspectRatio as string

### DIFF
--- a/packages/core/src/interfaces/models/Comment.ts
+++ b/packages/core/src/interfaces/models/Comment.ts
@@ -8,8 +8,10 @@ export interface GifData {
   url: string;
   gifUrl: string;
   gifPreviewUrl: string;
-  altText: string | undefined;
-  aspectRatio: number;
+  // The server's gif schema requires both as strings (aspectRatio is a string,
+  // e.g. "1.5", not a number).
+  altText: string;
+  aspectRatio: string;
 }
 
 export interface Comment {


### PR DESCRIPTION
## What

`@sublay/core` typed a comment's `GifData` as `aspectRatio: number` and `altText: string | undefined`. Both are wrong — the server treats them as required strings.

## Evidence (server is source of truth)

- **Request validation** — the create-comment body schema requires both as strings whenever a gif is present ([comments.schema.ts](https://github.com/sublay-io/server): `altText: z.string()`, `aspectRatio: z.string()`). The gif object itself is `nullable().optional()`, so `gif` is `GifData | null`, but its fields are not optional.
- **Storage/return** — `gif` is a plain `DataTypes.JSON` column, stored and returned verbatim (no transformation).
- **Model type** — the server's `IGif` interface declares `altText: string` and `aspectRatio: string` (both non-optional).

`@sublay/js` and `@sublay/node` already use `string`; this aligns `@sublay/core`.

## Change

`packages/core/src/interfaces/models/Comment.ts` — `GifData`:
- `aspectRatio: number` → `string`
- `altText: string | undefined` → `string`

## Verification

- core typecheck clean (esm + cjs)
- `build-all` green across all 4 packages — nothing internal relied on the old shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)