### PR TITLE
fix(core): only send spaces boolean flags when strictly true

### DIFF
--- a/packages/core/src/hooks/spaces/useFetchManySpaces.tsx
+++ b/packages/core/src/hooks/spaces/useFetchManySpaces.tsx
@@ -37,7 +37,11 @@ function useFetchManySpaces(): (params?: FetchManySpacesProps) => Promise<Pagina
       if (params?.searchName) queryParams.searchName = params.searchName;
       if (params?.searchDescription) queryParams.searchDescription = params.searchDescription;
       if (params?.searchAny) queryParams.searchAny = params.searchAny;
-      if (params?.memberOf !== undefined) queryParams.memberOf = params.memberOf;
+      // memberOf is an opt-in flag: the server only accepts the literal "true".
+      // Sending "false" (the default) fails validation with a 400. Use a strict
+      // === true check so a stray non-boolean (no runtime type enforcement) can't
+      // be coerced into wrongly opting in.
+      if (params?.memberOf === true) queryParams.memberOf = true;
       if (params?.parentSpaceId !== undefined) queryParams.parentSpaceId = params.parentSpaceId || "null";
       if (params?.include) {
         queryParams.include = Array.isArray(params.include)

--- a/packages/core/src/store/api/spacesApi.ts
+++ b/packages/core/src/store/api/spacesApi.ts
@@ -186,7 +186,11 @@ export const spacesApi = baseApi.injectEndpoints({
         if (params.searchDescription) queryParams.append("searchDescription", params.searchDescription);
         if (params.searchAny) queryParams.append("searchAny", params.searchAny);
         if (params.readingPermission) queryParams.append("readingPermission", params.readingPermission);
-        if (params.memberOf !== undefined) queryParams.append("memberOf", params.memberOf.toString());
+        // memberOf is an opt-in flag: the server only accepts the literal "true".
+        // Sending "false" (the default) fails validation with a 400. Use a strict
+        // === true check so a stray non-boolean (no runtime type enforcement) can't
+        // be coerced into wrongly opting in.
+        if (params.memberOf === true) queryParams.append("memberOf", "true");
         if (params.parentSpaceId !== undefined) {
           // Convert null to "null" string for API
           queryParams.append("parentSpaceId", params.parentSpaceId === null ? "null" : params.parentSpaceId);
@@ -448,7 +452,9 @@ export const spacesApi = baseApi.injectEndpoints({
         if (params.limit !== undefined) queryParams.append("limit", params.limit.toString());
         if (params.status) queryParams.append("status", params.status);
         if (params.role) queryParams.append("role", params.role);
-        if (params.all) queryParams.append("all", "true");
+        // `all` bypasses pagination; strict === true so a stray non-boolean
+        // (no runtime type enforcement) can't wrongly opt in.
+        if (params.all === true) queryParams.append("all", "true");
 
         const queryString = queryParams.toString();
         return {


### PR DESCRIPTION
## Summary

Fixes the 400 that makes `useSpaceList` root/space listing unusable (reported in #10).

The reported cause (`parentSpaceId=null`) is a red herring — the server **explicitly accepts** the literal `"null"` string and maps it to "top-level only." The actual culprit is **`memberOf=false`**:

- Server validates `memberOf` as `z.enum(["true"])` — an opt-in flag that only accepts the literal `"true"`.
- The SDK serializers appended `memberOf` whenever it wasn't `undefined`, and `useSpaceList` always passes a `memberOf` filter defaulting to `false`.
- So **every** `useSpaceList` fetch sent `memberOf=false` → 400.

## Changes

- `spacesApi.ts` (RTK Query `fetchSpaces`) and `useFetchManySpaces.tsx` (standalone hook) now append `memberOf` only when strictly `=== true`, matching the server's opt-in contract.
- Used a strict `=== true` check rather than a loose truthy check: the SDK does no runtime type validation, so a stray non-boolean (e.g. a JS caller passing the string `"false"`) must not be coerced into wrongly opting in.
- Tightened the sibling `all` flag in `fetchUserSpaces` to the same `=== true` check for consistency. (No 400 there — the server accepts both `"true"`/`"false"` for `all` — but the same coercion-safety reasoning applies.)

## Testing

- `@sublay/core` builds clean (ESM + CJS).
- Pre-existing test-file typecheck errors are unrelated to this change.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)