### PR TITLE
feat(core): add createdAt entity sortBy, deprecate new

### DIFF
--- a/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
@@ -59,7 +59,7 @@ function useFetchManyEntitiesWrapper(
   const {
     userId,
     limit = 10,
-    defaultSortBy = "new",
+    defaultSortBy = "createdAt",
     defaultSortByReaction = "upvote",
     defaultSortDir = "desc",
     defaultSortType = "auto",

--- a/packages/core/src/interfaces/EntityListSortByOptions.ts
+++ b/packages/core/src/interfaces/EntityListSortByOptions.ts
@@ -4,11 +4,19 @@ export type SortType = "auto" | "numeric" | "text" | "boolean" | "timestamp";
 
 export type SortByReaction = "upvote" | "downvote" | "like" | "love" | "wow" | "sad" | "angry" | "funny";
 
+/**
+ * @deprecated Use `"createdAt"` instead. `"new"` is a directional alias kept for
+ * backwards compatibility and will be removed in v8. The server still accepts it
+ * (it behaves identically to `"createdAt"`) but responds with deprecation headers.
+ */
+export type DeprecatedNewSortBy = "new";
+
 export type EntityListSortByOptions =
+  | "createdAt"
   | "top"
   | "hot"
-  | "new"
   | "controversial"
+  | DeprecatedNewSortBy
   | `metadata.${string}`;
 
 /**


### PR DESCRIPTION
Adds `createdAt` as the canonical entity `sortBy` value and marks `new` deprecated (directional name, inconsistent with other field-named sorts).

- `EntityListSortByOptions`: add `createdAt`; `new` kept via a `@deprecated DeprecatedNewSortBy` alias (still accepted by the server, behaves identically, removed in v8).
- `useFetchManyEntitiesWrapper`: default `defaultSortBy` changed `new` → `createdAt` (same behavior — `createdAt` DESC = newest first).

Scoped to entities only. Pairs with the server, js-sdk, node-sdk, and docs PRs.

Verification: `tsc` clean (pre-existing unrelated test-file type errors excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)