### PR TITLE
feat(comments): add createdAt sortBy + sortDir, deprecate new/old

### DIFF
--- a/packages/core/src/hooks/comments/useFetchManyComments.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyComments.tsx
@@ -10,6 +10,8 @@ export interface FetchManyCommentsProps {
   userId?: string | null | undefined;
   parentId?: string | null | undefined;
   sortBy?: CommentsSortByOptions;
+  /** Sort direction for `sortBy: "createdAt"`. Defaults to "desc". */
+  sortDir?: "asc" | "desc";
   page: number;
   limit?: number;
   include?: CommentIncludeParam;
@@ -34,6 +36,7 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
         userId,
         parentId,
         sortBy,
+        sortDir,
         page,
         limit,
         include,
@@ -60,6 +63,7 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
         limit,
       };
 
+      if (sortDir) params.sortDir = sortDir;
       if (entityId) params.entityId = entityId;
       if (userId) params.userId = userId;
       if (parentId) params.parentId = parentId;

--- a/packages/core/src/interfaces/CommentsSortByOptions.ts
+++ b/packages/core/src/interfaces/CommentsSortByOptions.ts
@@ -1,1 +1,12 @@
-export type CommentsSortByOptions = "top" | "new" | "old";
+/**
+ * @deprecated Use `"createdAt"` (with `sortDir`) instead. `"new"` (createdAt
+ * DESC) and `"old"` (createdAt ASC) are directional aliases kept for backwards
+ * compatibility and removed in v8. The server still accepts them (identical
+ * behavior) but responds with deprecation headers.
+ */
+export type DeprecatedCommentsSortBy = "new" | "old";
+
+export type CommentsSortByOptions =
+  | "createdAt"
+  | "top"
+  | DeprecatedCommentsSortBy;


### PR DESCRIPTION
Mirrors the server change (comments sort parity with entities).

- `CommentsSortByOptions`: add `createdAt` (canonical time sort); mark the directional aliases `new` (createdAt DESC) and `old` (createdAt ASC) deprecated via a `DeprecatedCommentsSortBy` type — still accepted by the server (identical behavior, removed in v8) with deprecation headers.
- `useFetchManyComments`: thread a new `sortDir` (`"asc"`/`"desc"`) param through to the request.

Scoped to the createdAt rename; `controversial` is intentionally left out of `CommentsSortByOptions` (it was never in that UI-level type — exposing it in the comment-section UI is a separate decision).

Pairs with the server, js-sdk, node-sdk, and docs PRs.

Verification: `tsc` clean for the changed files (the 4 pre-existing core errors are unchanged from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)