### PR TITLE
feat(comments): expose controversial sort option

### DIFF
--- a/packages/core/src/interfaces/CommentsSortByOptions.ts
+++ b/packages/core/src/interfaces/CommentsSortByOptions.ts
@@ -9,4 +9,5 @@ export type DeprecatedCommentsSortBy = "new" | "old";
 export type CommentsSortByOptions =
   | "createdAt"
   | "top"
+  | "controversial"
   | DeprecatedCommentsSortBy;


### PR DESCRIPTION
Adds `"controversial"` to `CommentsSortByOptions`.

The server has always supported `sortBy=controversial` for comments, and the comment hooks pass `sortBy` straight through to the request — so this is a purely additive **type-only** change. It surfaces the option to consumers (e.g. comment-section sort dropdowns) that the type previously limited to `createdAt`/`top`.

Closes the gap deliberately left open in the comments `createdAt` alignment PR (#32), where `controversial` was kept out of this UI-level type pending a decision to expose it. The comment docs already list `controversial` as a sort option, so no docs change is needed.

Verification: `tsc` clean for the changed file (the 4 pre-existing core errors are unchanged from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)