### PR TITLE
feat(comments): thread sortDir through comment-section hooks

### DIFF
--- a/packages/core/src/hooks/comments/useCommentSectionData.tsx
+++ b/packages/core/src/hooks/comments/useCommentSectionData.tsx
@@ -40,6 +40,8 @@ export interface UseCommentSectionDataProps {
   callbacks?: Record<string, (...args: any[]) => void> | undefined;
   limit?: number;
   defaultSortBy?: CommentsSortByOptions;
+  /** Initial sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
+  defaultSortDir?: "asc" | "desc";
   highlightedCommentId?: string | null;
   mentionTriggers?: MentionTriggers;
 }
@@ -77,6 +79,9 @@ export interface UseCommentSectionDataValues {
   loadMore: () => void;
   sortBy: CommentsSortByOptions | null;
   setSortBy: (newSortBy: CommentsSortByOptions) => void;
+  /** Sort direction for `sortBy: "createdAt"`. */
+  sortDir: "asc" | "desc";
+  setSortDir: (newSortDir: "asc" | "desc") => void;
   pushMention: User | null;
   selectedComment: Comment | null;
   setSelectedComment: (newSelectedComment: Comment | null) => void;
@@ -108,6 +113,7 @@ function useCommentSectionData(
     createIfNotFound,
 
     defaultSortBy = "top" as CommentsSortByOptions,
+    defaultSortDir = "desc",
     limit = 15,
     callbacks: callbacksProp = {},
     highlightedCommentId,
@@ -138,6 +144,8 @@ function useCommentSectionData(
     hasMore,
     sortBy,
     setSortBy,
+    sortDir,
+    setSortDir,
     loadMore,
     addCommentsToTree,
     removeCommentFromTree,
@@ -145,6 +153,7 @@ function useCommentSectionData(
   } = useEntityComments({
     entityId: entity?.id,
     defaultSortBy,
+    defaultSortDir,
     limit,
     include: "user",
   });
@@ -508,6 +517,8 @@ function useCommentSectionData(
     loadMore,
     sortBy,
     setSortBy,
+    sortDir,
+    setSortDir,
     pushMention,
     selectedComment,
     setSelectedComment,

--- a/packages/core/src/hooks/comments/useEntityComments.tsx
+++ b/packages/core/src/hooks/comments/useEntityComments.tsx
@@ -12,6 +12,8 @@ export interface UseEntityCommentsProps {
   entityId: string | undefined | null;
   limit?: number;
   defaultSortBy?: CommentsSortByOptions;
+  /** Initial sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
+  defaultSortDir?: "asc" | "desc";
   include?: CommentIncludeParam;
   /**
    * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
@@ -30,6 +32,9 @@ export interface UseEntityCommentsValues {
   hasMore: boolean;
   sortBy: CommentsSortByOptions | null;
   setSortBy: (newSortBy: CommentsSortByOptions) => void;
+  /** Sort direction for `sortBy: "createdAt"`. */
+  sortDir: "asc" | "desc";
+  setSortDir: (newSortDir: "asc" | "desc") => void;
   loadMore: () => void;
   addCommentsToTree: (
     newComments: Comment[] | undefined,
@@ -45,7 +50,8 @@ function useEntityComments(
   const {
     entityId,
     limit = 10,
-    defaultSortBy = "new",
+    defaultSortBy = "createdAt",
+    defaultSortDir = "desc",
     include,
     spaceReputationId,
     spaceReputationDescendants,
@@ -60,6 +66,7 @@ function useEntityComments(
   const [hasMoreState, setHasMoreState] = useState(true); // required to trigger rerenders
 
   const [sortBy, setSortBy] = useState<CommentsSortByOptions>(defaultSortBy);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">(defaultSortDir);
   const [page, setPage] = useState(1);
 
   const [entityCommentsTree, setEntityCommentsTree] =
@@ -129,6 +136,7 @@ function useEntityComments(
         entityId,
         page: 1,
         sortBy,
+        sortDir,
         limit,
         include,
         spaceReputationId,
@@ -147,7 +155,7 @@ function useEntityComments(
       loading.current = false;
       setLoadingState(false);
     }
-  }, [fetchManyComments, limit, sortBy, entityId, include, spaceReputationId, spaceReputationDescendants]);
+  }, [fetchManyComments, limit, sortBy, sortDir, entityId, include, spaceReputationId, spaceReputationDescendants]);
 
   const loadMore = () => {
     if (loading.current || !hasMore.current) return;
@@ -175,6 +183,7 @@ function useEntityComments(
           entityId,
           page,
           sortBy,
+          sortDir,
           limit,
           spaceReputationId,
           spaceReputationDescendants,
@@ -208,6 +217,8 @@ function useEntityComments(
     hasMore: hasMoreState,
     sortBy,
     setSortBy,
+    sortDir,
+    setSortDir,
     loadMore,
     addCommentsToTree,
     removeCommentFromTree,

--- a/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
@@ -12,6 +12,8 @@ export interface UseFetchManyCommentsWrapperProps {
   limit?: number;
   include?: CommentIncludeParam;
   defaultSortBy?: CommentsSortByOptions;
+  /** Initial sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
+  defaultSortDir?: "asc" | "desc";
   /**
    * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
    * forms: a space `<uuid>`, `"none"`, or `"context"`.
@@ -27,6 +29,9 @@ export interface UseFetchManyCommentsWrapperValues {
   hasMore: boolean;
   sortBy: CommentsSortByOptions | null;
   setSortBy: (newSortBy: CommentsSortByOptions) => void;
+  /** Sort direction for `sortBy: "createdAt"`. */
+  sortDir: "asc" | "desc";
+  setSortDir: (newSortDir: "asc" | "desc") => void;
   loadMore: () => void;
 }
 
@@ -39,7 +44,8 @@ function useFetchManyCommentsWrapper(
     parentId,
     sourceId,
     limit = 10,
-    defaultSortBy = "new",
+    defaultSortBy = "createdAt",
+    defaultSortDir = "desc",
     include,
     spaceReputationId,
     spaceReputationDescendants,
@@ -53,6 +59,7 @@ function useFetchManyCommentsWrapper(
   const [hasMoreState, setHasMoreState] = useState(true);
 
   const [sortBy, setSortBy] = useState<CommentsSortByOptions>(defaultSortBy);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">(defaultSortDir);
   const [page, setPage] = useState(1);
   const [comments, setComments] = useState<Comment[]>([]);
 
@@ -77,6 +84,7 @@ function useFetchManyCommentsWrapper(
         sourceId,
         page: 1,
         sortBy,
+        sortDir,
         limit,
         include,
         spaceReputationId,
@@ -99,6 +107,7 @@ function useFetchManyCommentsWrapper(
     fetchManyComments,
     limit,
     sortBy,
+    sortDir,
     entityId,
     userId,
     parentId,
@@ -132,6 +141,7 @@ function useFetchManyCommentsWrapper(
           sourceId,
           page,
           sortBy,
+          sortDir,
           limit,
           include,
           spaceReputationId,
@@ -164,6 +174,7 @@ function useFetchManyCommentsWrapper(
     parentId,
     sourceId,
     sortBy,
+    sortDir,
     limit,
     include,
     spaceReputationId,
@@ -176,6 +187,8 @@ function useFetchManyCommentsWrapper(
     hasMore: hasMoreState,
     sortBy,
     setSortBy,
+    sortDir,
+    setSortDir,
     loadMore,
   };
 }

--- a/packages/core/src/hooks/comments/useReplies.tsx
+++ b/packages/core/src/hooks/comments/useReplies.tsx
@@ -9,6 +9,8 @@ import { isUUID } from "../../utils/isUUID";
 export interface UseRepliesProps {
   commentId: string;
   sortBy: CommentsSortByOptions;
+  /** Sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
+  sortDir?: "asc" | "desc";
 }
 
 export interface UseRepliesValues {
@@ -19,7 +21,7 @@ export interface UseRepliesValues {
   setPage: Dispatch<SetStateAction<number>>;
 }
 
-function useReplies({ commentId, sortBy }: UseRepliesProps): UseRepliesValues {
+function useReplies({ commentId, sortBy, sortDir }: UseRepliesProps): UseRepliesValues {
   const fetchManyComments = useFetchManyComments();
   const { addCommentsToTree, entityCommentsTree } = useCommentSection();
 
@@ -63,6 +65,7 @@ function useReplies({ commentId, sortBy }: UseRepliesProps): UseRepliesValues {
           parentId: commentId,
           page,
           sortBy,
+          sortDir,
           limit: 5,
           include: "user", // Always include user for replies display
         });


### PR DESCRIPTION
Adds a `sortDir` ("asc"/"desc") control to the stateful comment hooks so consumers can drive `sortBy: "createdAt"` in either direction — replacing the deprecated `new`/`old` directional pair.

- **useEntityComments** / **useFetchManyCommentsWrapper**: new `defaultSortDir` prop + `sortDir`/`setSortDir` state, forwarded to the fetch. Also bumps their stale `defaultSortBy` default from `"new"` to `"createdAt"`.
- **useCommentSectionData** (and the `CommentSection` provider/context, which inherit its types): expose `sortDir`/`setSortDir`.
- **useReplies**: accept + forward `sortDir` so replies follow the section.

**Non-breaking**: `sortDir` defaults to `"desc"` everywhere, so existing `createdAt`/`new` behavior (newest first) is unchanged.

Enables the CLI comment components to migrate their New/Old sort buttons to `createdAt` + `sortDir` (companion CLI PR to follow after this releases). Docs PR: sublay-io/docs#13 (documents the new `sortDir`).

Verification: `tsc` clean for the changed files (the 4 pre-existing core errors are unchanged from `main`); comment-section context test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)