### PR TITLE
feat(search): includeChildSpaces on useAskContent/useSearchContent

### DIFF
--- a/packages/core/src/hooks/search/useAskContent.test.tsx
+++ b/packages/core/src/hooks/search/useAskContent.test.tsx
@@ -60,6 +60,26 @@ describe("useAskContent", () => {
     expect(JSON.parse(init.body)).toMatchObject({ query: "What is this about?" });
   });
 
+  it("forwards spaceId + includeChildSpaces in the request body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeStreamResponse([sse("done", {})]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHookWithAxios(() => useAskContent());
+
+    act(() => {
+      result.current.ask({ query: "hello", spaceId: "space-1", includeChildSpaces: true });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toMatchObject({
+      query: "hello",
+      spaceId: "space-1",
+      includeChildSpaces: true,
+    });
+  });
+
   it("attaches an Authorization header when an access token is present", async () => {
     const fetchMock = vi.fn().mockResolvedValue(makeStreamResponse([sse("done", {})]));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/core/src/hooks/search/useAskContent.ts
+++ b/packages/core/src/hooks/search/useAskContent.ts
@@ -9,6 +9,12 @@ export interface UseAskContentProps {
   query: string;
   sourceTypes?: ("entity" | "comment" | "message")[];
   spaceId?: string;
+  /**
+   * With a `spaceId`, also search every space nested under it (children,
+   * grandchildren — the whole subtree, any depth). Ignored without a `spaceId`.
+   * Defaults to false (exact-space search).
+   */
+  includeChildSpaces?: boolean;
   conversationId?: string;
   limit?: number;
   /**
@@ -98,7 +104,7 @@ export default function useAskContent(): UseAskContentReturn {
   }, []);
 
   const ask = useCallback(
-    ({ query, sourceTypes, spaceId, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseAskContentProps) => {
+    ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseAskContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
@@ -118,6 +124,7 @@ export default function useAskContent(): UseAskContentReturn {
         query,
         ...(sourceTypes && { sourceTypes }),
         ...(spaceId && { spaceId }),
+        ...(includeChildSpaces && { includeChildSpaces }),
         ...(conversationId && { conversationId }),
         ...(limit && { limit }),
       });

--- a/packages/core/src/hooks/search/useSearchContent.test.tsx
+++ b/packages/core/src/hooks/search/useSearchContent.test.tsx
@@ -31,7 +31,7 @@ describe("useSearchContent", () => {
     expect(call.body).toMatchObject({ query: "hello" });
   });
 
-  it("passes sourceTypes, spaceId, conversationId and spaceReputation params through", async () => {
+  it("passes sourceTypes, spaceId, includeChildSpaces, conversationId and spaceReputation params through", async () => {
     const { result, axiosPrivate } = renderHookWithAxios(() => useSearchContent());
 
     axiosPrivate.mockResponse("post", []);
@@ -41,6 +41,7 @@ describe("useSearchContent", () => {
         query: "hello",
         sourceTypes: ["entity", "comment"],
         spaceId: "space-1",
+        includeChildSpaces: true,
         conversationId: "conversation-1",
         limit: 5,
         spaceReputationId: "context",
@@ -51,6 +52,7 @@ describe("useSearchContent", () => {
     expect(call.body).toMatchObject({
       sourceTypes: ["entity", "comment"],
       spaceId: "space-1",
+      includeChildSpaces: true,
       conversationId: "conversation-1",
       limit: 5,
     });

--- a/packages/core/src/hooks/search/useSearchContent.ts
+++ b/packages/core/src/hooks/search/useSearchContent.ts
@@ -16,6 +16,12 @@ export interface UseSearchContentProps {
   query: string;
   sourceTypes?: ("entity" | "comment" | "message")[];
   spaceId?: string;
+  /**
+   * With a `spaceId`, also search every space nested under it (children,
+   * grandchildren — the whole subtree, any depth). Ignored without a `spaceId`.
+   * Defaults to false (exact-space search).
+   */
+  includeChildSpaces?: boolean;
   conversationId?: string;
   limit?: number;
   /**
@@ -45,7 +51,7 @@ export default function useSearchContent(): UseSearchContentReturn {
   const [error, setError] = useState<string | null>(null);
 
   const search = useCallback(
-    async ({ query, sourceTypes, spaceId, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseSearchContentProps) => {
+    async ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseSearchContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
@@ -57,7 +63,7 @@ export default function useSearchContent(): UseSearchContentReturn {
         if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
         const response = await axios.post<ContentSearchResult[]>(
           `/${projectId}/search/content`,
-          { query, sourceTypes, spaceId, conversationId, limit },
+          { query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit },
           { params }
         );
         setResults(response.data);


### PR DESCRIPTION
## What

Adds an optional `includeChildSpaces?: boolean` to `useAskContent` and `useSearchContent`, forwarded in the request body.

## Why

Pairs with the server flag (sublay-io/server-hosted#47): when set with a `spaceId`, the ask/search covers the space plus its whole child-space subtree (any depth). Default off; mirrors the server param name exactly.

## Notes

- Forwarding assertions added to both hook tests; full search suite green (20/20).
- Re-exported automatically by `@sublay/react-js` / `react-native` / `expo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)