### PR TITLE
feat(core): consolidate space-reputation params into a spaceReputation object

### DIFF
--- a/packages/core/src/hooks/__tests__/spaceReputationSerialization.test.tsx
+++ b/packages/core/src/hooks/__tests__/spaceReputationSerialization.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+
+import {
+  renderHookWithAxios,
+  resetAxiosMocks,
+} from "../../test-utils";
+import useFetchManyComments from "../comments/useFetchManyComments";
+import useFetchUser from "../users/useFetchUser";
+import type { PaginatedResponse } from "../../interfaces/PaginatedResponse";
+import type { Comment } from "../../interfaces/models/Comment";
+
+/**
+ * Serialization regression guard (Task 2.4).
+ *
+ * The new `spaceReputation` object must NEVER reach a query-string serializer
+ * un-normalized. If a nested `{ spaceId, includeDescendants }` object survives
+ * into axios `params`, axios serializes it to bracketed params
+ * (`spaceReputation[spaceId]=…`) which the server IGNORES — the new (primary)
+ * form silently no-ops while the deprecated flat props still work. Typecheck
+ * and the old flat-prop tests both stay green when this happens; these tests
+ * are the only thing that catches it.
+ *
+ * For axios-backed hooks the harness records the `config.params` object handed
+ * to axios. We assert (a) the flat keys are present and (b) NO `spaceReputation`
+ * key survived — a bracket leak would manifest as a leftover `spaceReputation`
+ * object on `params`. We additionally serialize the params with a URLSearchParams
+ * round-trip to confirm the emitted query string is flat, never bracketed.
+ */
+
+function makePage(): PaginatedResponse<Comment> {
+  return {
+    data: [],
+    pagination: { page: 1, pageSize: 10, totalPages: 1, totalItems: 0, hasMore: false },
+  };
+}
+
+/** Flattens a params object the way a query serializer would, then asserts shape. */
+function serializedKeys(params: Record<string, unknown>): string[] {
+  return Object.keys(params);
+}
+
+afterEach(() => {
+  resetAxiosMocks();
+});
+
+describe("spaceReputation serialization regression guard (core hooks)", () => {
+  it("a context-variant hook (useFetchManyComments) serializes the OBJECT form to flat params", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useFetchManyComments());
+
+    axiosPrivate.mockResponse("get", makePage());
+
+    await act(async () => {
+      await result.current({
+        entityId: "entity-1",
+        page: 1,
+        sortBy: "new",
+        spaceReputation: { spaceId: "context", includeDescendants: true },
+      });
+    });
+
+    const [call] = axiosPrivate.calls("get");
+    const params = (call.config?.params ?? {}) as Record<string, unknown>;
+
+    // Flat keys present with the object's values.
+    expect(params).toMatchObject({
+      spaceReputationId: "context",
+      spaceReputationDescendants: true,
+    });
+    // The object must NOT survive into the serialized params (would bracket-leak).
+    expect(params).not.toHaveProperty("spaceReputation");
+    expect(serializedKeys(params)).not.toContain("spaceReputation");
+
+    // The emitted query string is flat — never `spaceReputation[spaceId]=…`.
+    const qs = new URLSearchParams(
+      Object.entries(params).map(([k, v]) => [k, String(v)]),
+    ).toString();
+    expect(qs).toContain("spaceReputationId=context");
+    expect(qs).toContain("spaceReputationDescendants=true");
+    expect(qs).not.toContain("spaceReputation%5B"); // encoded `spaceReputation[`
+    expect(qs).not.toContain("spaceReputation[");
+  });
+
+  it("the OBJECT form and the equivalent FLAT form produce identical serialized params", async () => {
+    // Object form
+    const objHarness = renderHookWithAxios(() => useFetchManyComments());
+    objHarness.axiosPrivate.mockResponse("get", makePage());
+    await act(async () => {
+      await objHarness.result.current({
+        entityId: "entity-1",
+        page: 1,
+        sortBy: "new",
+        spaceReputation: { spaceId: "space-9", includeDescendants: false },
+      });
+    });
+    const objParams = (objHarness.axiosPrivate.calls("get")[0].config?.params ??
+      {}) as Record<string, unknown>;
+    resetAxiosMocks();
+
+    // Equivalent flat (deprecated) form
+    const flatHarness = renderHookWithAxios(() => useFetchManyComments());
+    flatHarness.axiosPrivate.mockResponse("get", makePage());
+    await act(async () => {
+      await flatHarness.result.current({
+        entityId: "entity-1",
+        page: 1,
+        sortBy: "new",
+        spaceReputationId: "space-9",
+        spaceReputationDescendants: false,
+      });
+    });
+    const flatParams = (flatHarness.axiosPrivate.calls("get")[0].config?.params ??
+      {}) as Record<string, unknown>;
+
+    expect(objParams).toMatchObject({
+      spaceReputationId: "space-9",
+      spaceReputationDescendants: false,
+    });
+    expect(flatParams).toMatchObject({
+      spaceReputationId: "space-9",
+      spaceReputationDescendants: false,
+    });
+    expect(objParams).not.toHaveProperty("spaceReputation");
+  });
+
+  it("a users-variant hook (useFetchUser) serializes the OBJECT form to flat params", async () => {
+    const { result, axiosPublic } = renderHookWithAxios(() => useFetchUser());
+
+    axiosPublic.mockResponse("get", { id: "user-1" });
+
+    await act(async () => {
+      await result.current({
+        userId: "user-1",
+        spaceReputation: { spaceId: "none" },
+      });
+    });
+
+    const [call] = axiosPublic.calls("get");
+    const params = (call.config?.params ?? {}) as Record<string, unknown>;
+
+    expect(params).toMatchObject({ spaceReputationId: "none" });
+    expect(params).not.toHaveProperty("spaceReputation");
+    // includeDescendants was omitted in the object → flat key absent.
+    expect(params).not.toHaveProperty("spaceReputationDescendants");
+  });
+});

--- a/packages/core/src/hooks/chat/conversations/useConversationMembers.tsx
+++ b/packages/core/src/hooks/chat/conversations/useConversationMembers.tsx
@@ -3,16 +3,11 @@ import { ConversationMember } from "../../../interfaces/models/ConversationMembe
 import useAxiosPrivate from "../../../config/useAxiosPrivate";
 import useProject from "../../projects/useProject";
 import { handleError } from "../../../utils/handleError";
+import { SpaceReputationContextParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
-export interface UseConversationMembersProps {
+export interface UseConversationMembersProps extends SpaceReputationContextParams {
   conversationId: string;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseConversationMembersValues {
@@ -30,11 +25,19 @@ export interface UseConversationMembersValues {
 
 function useConversationMembers({
   conversationId,
+  spaceReputation,
   spaceReputationId,
   spaceReputationDescendants,
 }: UseConversationMembersProps): UseConversationMembersValues {
   const { projectId } = useProject();
   const axios = useAxiosPrivate();
+
+  const reputationParams = buildSpaceReputationParams({
+    spaceReputation,
+    spaceReputationId,
+    spaceReputationDescendants,
+  });
+  const reputationKey = JSON.stringify(reputationParams);
 
   const [members, setMembers] = useState<ConversationMember[]>([]);
   const [loading, setLoading] = useState(false);
@@ -45,9 +48,7 @@ function useConversationMembers({
     const fetch = async () => {
       setLoading(true);
       try {
-        const params: Record<string, any> = { limit: 100 };
-        if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-        if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+        const params: Record<string, any> = { limit: 100, ...reputationParams };
         const response = await axios.get(
           `/${projectId}/chat/conversations/${conversationId}/members`,
           { params }
@@ -61,7 +62,7 @@ function useConversationMembers({
     };
 
     fetch();
-  }, [projectId, conversationId, spaceReputationId, spaceReputationDescendants]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectId, conversationId, reputationKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const addMember = useCallback(
     async ({ userId }: { userId: string }) => {

--- a/packages/core/src/hooks/chat/messages/useFetchManyChatMessages.tsx
+++ b/packages/core/src/hooks/chat/messages/useFetchManyChatMessages.tsx
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 import { ChatMessage } from "../../../interfaces/models/ChatMessage";
 import useAxiosPrivate from "../../../config/useAxiosPrivate";
 import useProject from "../../projects/useProject";
+import { SpaceReputationContextParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
 export interface MessageFilters {
   /**
@@ -12,7 +14,7 @@ export interface MessageFilters {
   hasReplies?: boolean;
 }
 
-export interface FetchManyChatMessagesProps {
+export interface FetchManyChatMessagesProps extends SpaceReputationContextParams {
   conversationId: string;
   /** Restrict to replies of this message (thread view). */
   parentId?: string | null;
@@ -26,13 +28,6 @@ export interface FetchManyChatMessagesProps {
   /** When `true`, the server populates the `files` field on each message. */
   includeFiles?: boolean;
   filters?: MessageFilters;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface FetchManyChatMessagesResponse {
@@ -72,6 +67,7 @@ function useFetchManyChatMessages(): (
         sort,
         includeFiles,
         filters,
+        spaceReputation,
         spaceReputationId,
         spaceReputationDescendants,
       } = props;
@@ -79,15 +75,20 @@ function useFetchManyChatMessages(): (
       if (!projectId) throw new Error("No project specified");
       if (!conversationId) throw new Error("No conversation specified");
 
-      const params: Record<string, any> = { limit };
+      const params: Record<string, any> = {
+        limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
       if (sort) params.sort = sort;
       if (parentId) params.parentId = parentId;
       if (before) params.before = before;
       if (after) params.after = after;
       if (includeFiles) params.include = "files";
       if (filters) params.filters = filters;
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<FetchManyChatMessagesResponse>(
         `/${projectId}/chat/conversations/${conversationId}/messages`,

--- a/packages/core/src/hooks/chat/messages/useFetchManyChatMessagesWrapper.tsx
+++ b/packages/core/src/hooks/chat/messages/useFetchManyChatMessagesWrapper.tsx
@@ -4,8 +4,9 @@ import { handleError } from "../../../utils/handleError";
 import useFetchManyChatMessages, {
   MessageFilters,
 } from "./useFetchManyChatMessages";
+import { SpaceReputationContextParams } from "../../../interfaces/SpaceReputation";
 
-export interface UseFetchManyChatMessagesWrapperProps {
+export interface UseFetchManyChatMessagesWrapperProps extends SpaceReputationContextParams {
   conversationId: string;
   /** Restrict to replies of this message (thread view). */
   parentId?: string | null;
@@ -20,13 +21,6 @@ export interface UseFetchManyChatMessagesWrapperProps {
   /** When `true`, the server populates the `files` field on each message. */
   includeFiles?: boolean;
   filters?: MessageFilters;
-  /**
-   * Opt into per-row `spaceReputation` on embedded message authors. Accepted
-   * forms: a space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyChatMessagesWrapperValues {
@@ -55,9 +49,15 @@ function useFetchManyChatMessagesWrapper(
     sort = "desc",
     includeFiles,
     filters,
+    spaceReputation,
     spaceReputationId,
     spaceReputationDescendants,
   } = props;
+
+  // Forwarded to the leaf fetcher, which flattens it via
+  // buildSpaceReputationParams before it reaches the serializer.
+  const reputation = { spaceReputation, spaceReputationId, spaceReputationDescendants };
+  const reputationKey = JSON.stringify(reputation);
 
   const fetchMany = useFetchManyChatMessages();
 
@@ -96,8 +96,7 @@ function useFetchManyChatMessagesWrapper(
         sort,
         includeFiles,
         filters,
-        spaceReputationId,
-        spaceReputationDescendants,
+        ...reputation,
       });
       setMessages(res.messages);
       hasMoreRef.current = res.hasMore;
@@ -110,7 +109,7 @@ function useFetchManyChatMessagesWrapper(
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, spaceReputationId, spaceReputationDescendants, advanceCursor]);
+  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, reputationKey, advanceCursor]);
 
   const loadMore = useCallback(async () => {
     if (loadingRef.current || !hasMoreRef.current || !cursorRef.current) return;
@@ -124,8 +123,7 @@ function useFetchManyChatMessagesWrapper(
         sort,
         includeFiles,
         filters,
-        spaceReputationId,
-        spaceReputationDescendants,
+        ...reputation,
         ...(sort === "asc"
           ? { after: cursorRef.current }
           : { before: cursorRef.current }),
@@ -141,7 +139,7 @@ function useFetchManyChatMessagesWrapper(
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, spaceReputationId, spaceReputationDescendants, advanceCursor]);
+  }, [fetchMany, conversationId, parentId, limit, sort, includeFiles, filtersKey, reputationKey, advanceCursor]);
 
   useEffect(() => {
     refetch();

--- a/packages/core/src/hooks/chat/messages/useSendMessage.tsx
+++ b/packages/core/src/hooks/chat/messages/useSendMessage.tsx
@@ -13,8 +13,10 @@ import { Mention } from "../../../interfaces/models/Mention";
 import useAxiosPrivate from "../../../config/useAxiosPrivate";
 import useProject from "../../projects/useProject";
 import { handleError } from "../../../utils/handleError";
+import { SpaceReputationContextParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
-export interface SendMessageParams {
+export interface SendMessageParams extends SpaceReputationContextParams {
   content?: string;
   gif?: GifData;
   mentions?: Mention[];
@@ -22,17 +24,6 @@ export interface SendMessageParams {
   quotedMessageId?: string | null;
   parentMessageId?: string | null;
   files?: File[];
-  /**
-   * Opt into `spaceReputation` on the enriched sender returned in the response.
-   * Accepted forms: a space `<uuid>`, `"none"`, or `"context"`. Sent as a query
-   * param so it works for both the JSON and multipart request shapes.
-   */
-  spaceReputationId?: string;
-  /**
-   * Include reputation accrued in descendant spaces. Only honored when
-   * `spaceReputationId` is an explicit `<uuid>`.
-   */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseSendMessageProps {
@@ -60,17 +51,18 @@ function useSendMessage({
       quotedMessageId,
       parentMessageId,
       files,
+      spaceReputation,
       spaceReputationId,
       spaceReputationDescendants,
     }: SendMessageParams): Promise<ChatMessage> => {
       if (!projectId) throw new Error("No projectId available.");
       if (!conversationId) throw new Error("No conversationId provided.");
 
-      const reputationParams: Record<string, any> = {};
-      if (spaceReputationId !== undefined)
-        reputationParams.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined)
-        reputationParams.spaceReputationDescendants = spaceReputationDescendants;
+      const reputationParams = buildSpaceReputationParams({
+        spaceReputation,
+        spaceReputationId,
+        spaceReputationDescendants,
+      });
 
       const localId = crypto.randomUUID();
       const now = new Date().toISOString();

--- a/packages/core/src/hooks/comments/useEntityComments.tsx
+++ b/packages/core/src/hooks/comments/useEntityComments.tsx
@@ -7,21 +7,15 @@ import { EntityCommentsTree } from "../../interfaces/EntityCommentsTree";
 import { addCommentsToTree as addCommentsToTreeHandler } from "../../helpers/addCommentsToTree";
 import { removeCommentFromTree as removeCommentFromTreeHandler } from "../../helpers/removeCommentFromTree";
 import { markCommentAsDeletedInTree as markCommentAsDeletedInTreeHandler } from "../../helpers/markCommentAsDeletedInTree";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
 
-export interface UseEntityCommentsProps {
+export interface UseEntityCommentsProps extends SpaceReputationContextParams {
   entityId: string | undefined | null;
   limit?: number;
   defaultSortBy?: CommentsSortByOptions;
   /** Initial sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
   defaultSortDir?: "asc" | "desc";
   include?: CommentIncludeParam;
-  /**
-   * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
-   * forms: a space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseEntityCommentsValues {
@@ -53,9 +47,15 @@ function useEntityComments(
     defaultSortBy = "createdAt",
     defaultSortDir = "desc",
     include,
+    spaceReputation,
     spaceReputationId,
     spaceReputationDescendants,
   } = props;
+
+  // Forwarded to the leaf fetcher, which flattens it via
+  // buildSpaceReputationParams before it reaches the serializer.
+  const reputation = { spaceReputation, spaceReputationId, spaceReputationDescendants };
+  const reputationKey = JSON.stringify(reputation);
 
   const fetchManyComments = useFetchManyComments();
 
@@ -139,8 +139,7 @@ function useEntityComments(
         sortDir,
         limit,
         include,
-        spaceReputationId,
-        spaceReputationDescendants,
+        ...reputation,
       });
 
       if (response) {
@@ -155,7 +154,7 @@ function useEntityComments(
       loading.current = false;
       setLoadingState(false);
     }
-  }, [fetchManyComments, limit, sortBy, sortDir, entityId, include, spaceReputationId, spaceReputationDescendants]);
+  }, [fetchManyComments, limit, sortBy, sortDir, entityId, include, reputationKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadMore = () => {
     if (loading.current || !hasMore.current) return;
@@ -185,8 +184,7 @@ function useEntityComments(
           sortBy,
           sortDir,
           limit,
-          spaceReputationId,
-          spaceReputationDescendants,
+          ...reputation,
         });
 
         if (response) {

--- a/packages/core/src/hooks/comments/useFetchComment.tsx
+++ b/packages/core/src/hooks/comments/useFetchComment.tsx
@@ -2,24 +2,19 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import { Comment, CommentIncludeParam } from "../../interfaces/models/Comment";
 import axios from "../../config/axios";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchCommentProps {
+export interface FetchCommentProps extends SpaceReputationContextParams {
   commentId: string;
   include?: CommentIncludeParam;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchComment(): (props: FetchCommentProps) => Promise<{ comment: Comment }> {
   const { projectId } = useProject();
 
   const fetchComment = useCallback(
-    async ({ commentId, include, spaceReputationId, spaceReputationDescendants }: FetchCommentProps) => {
+    async ({ commentId, include, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchCommentProps) => {
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -28,13 +23,17 @@ function useFetchComment(): (props: FetchCommentProps) => Promise<{ comment: Com
         throw new Error("No comment ID passed");
       }
 
-      const params: Record<string, any> = {};
+      const params: Record<string, any> = {
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       if (include) {
         params.include = Array.isArray(include) ? include.join(',') : include;
       }
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/comments/${commentId}`, {
         params,

--- a/packages/core/src/hooks/comments/useFetchManyComments.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyComments.tsx
@@ -4,8 +4,10 @@ import { Comment, CommentIncludeParam } from "../../interfaces/models/Comment";
 import { PaginatedResponse } from "../../interfaces/PaginatedResponse";
 import useProject from "../projects/useProject";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchManyCommentsProps {
+export interface FetchManyCommentsProps extends SpaceReputationContextParams {
   entityId?: string | null | undefined;
   userId?: string | null | undefined;
   parentId?: string | null | undefined;
@@ -16,13 +18,6 @@ export interface FetchManyCommentsProps {
   limit?: number;
   include?: CommentIncludeParam;
   sourceId?: string | null | undefined;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<PaginatedResponse<Comment>> {
@@ -41,6 +36,7 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
         limit,
         include,
         sourceId,
+        spaceReputation,
         spaceReputationId,
         spaceReputationDescendants,
       } = props;
@@ -61,6 +57,11 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
         sortBy,
         page,
         limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
 
       if (sortDir) params.sortDir = sortDir;
@@ -68,8 +69,6 @@ function useFetchManyComments(): (props: FetchManyCommentsProps) => Promise<Pagi
       if (userId) params.userId = userId;
       if (parentId) params.parentId = parentId;
       if (sourceId) params.sourceId = sourceId;
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       if (include) {
         params.include = Array.isArray(include) ? include.join(',') : include;

--- a/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
+++ b/packages/core/src/hooks/comments/useFetchManyCommentsWrapper.tsx
@@ -3,8 +3,9 @@ import { CommentsSortByOptions } from "../../interfaces/CommentsSortByOptions";
 import { Comment, CommentIncludeParam } from "../../interfaces/models/Comment";
 import useFetchManyComments from "./useFetchManyComments";
 import { handleError } from "../../utils/handleError";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
 
-export interface UseFetchManyCommentsWrapperProps {
+export interface UseFetchManyCommentsWrapperProps extends SpaceReputationContextParams {
   entityId?: string | null;
   userId?: string | null;
   parentId?: string | null;
@@ -14,13 +15,6 @@ export interface UseFetchManyCommentsWrapperProps {
   defaultSortBy?: CommentsSortByOptions;
   /** Initial sort direction for `sortBy: "createdAt"`. Defaults to `"desc"`. */
   defaultSortDir?: "asc" | "desc";
-  /**
-   * Opt into per-row `spaceReputation` on embedded comment authors. Accepted
-   * forms: a space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyCommentsWrapperValues {
@@ -47,9 +41,16 @@ function useFetchManyCommentsWrapper(
     defaultSortBy = "createdAt",
     defaultSortDir = "desc",
     include,
+    spaceReputation,
     spaceReputationId,
     spaceReputationDescendants,
   } = props;
+
+  // Forwarded to the leaf fetcher, which flattens it via
+  // buildSpaceReputationParams before it reaches the serializer.
+  const reputation = { spaceReputation, spaceReputationId, spaceReputationDescendants };
+  const reputationKey = JSON.stringify(reputation);
+
   const fetchManyComments = useFetchManyComments();
 
   const loading = useRef(true);
@@ -87,8 +88,7 @@ function useFetchManyCommentsWrapper(
         sortDir,
         limit,
         include,
-        spaceReputationId,
-        spaceReputationDescendants,
+        ...reputation,
       });
 
       if (response) {
@@ -113,9 +113,8 @@ function useFetchManyCommentsWrapper(
     parentId,
     sourceId,
     include,
-    spaceReputationId,
-    spaceReputationDescendants,
-  ]);
+    reputationKey,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadMore = () => {
     if (loading.current || !hasMore.current) return;
@@ -144,8 +143,7 @@ function useFetchManyCommentsWrapper(
           sortDir,
           limit,
           include,
-          spaceReputationId,
-          spaceReputationDescendants,
+          ...reputation,
         });
 
         if (response) {
@@ -177,9 +175,8 @@ function useFetchManyCommentsWrapper(
     sortDir,
     limit,
     include,
-    spaceReputationId,
-    spaceReputationDescendants,
-  ]);
+    reputationKey,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     comments,

--- a/packages/core/src/hooks/entities/useFetchEntity.tsx
+++ b/packages/core/src/hooks/entities/useFetchEntity.tsx
@@ -2,17 +2,12 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import { Entity, EntityIncludeParam } from "../../interfaces/models/Entity";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchEntityProps {
+export interface FetchEntityProps extends SpaceReputationContextParams {
   entityId: string;
   include?: EntityIncludeParam;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
@@ -20,7 +15,7 @@ function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
   const { projectId } = useProject();
 
   const fetchEntity = useCallback(
-    async ({ entityId, include, spaceReputationId, spaceReputationDescendants }: FetchEntityProps) => {
+    async ({ entityId, include, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchEntityProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -31,10 +26,12 @@ function useFetchEntity(): (props: FetchEntityProps) => Promise<Entity> {
 
       const params: Record<string, any> = {
         include: Array.isArray(include) ? include.join(",") : include,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined)
-        params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/entities/${entityId}`, {
         params,

--- a/packages/core/src/hooks/entities/useFetchManyEntities.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntities.tsx
@@ -11,6 +11,8 @@ import { ContentFilters } from "../../interfaces/entity-filters/ContentFilters";
 import { AttachmentsFilters } from "../../interfaces/entity-filters/AttachmentsFilters";
 import { LocationFilters } from "../../interfaces/entity-filters/LocationFilters";
 import { MetadataFilters } from "../../interfaces/entity-filters/MetadataFilters";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
 // Helper to serialize objects into bracket notation for query params
 const serializeObject = (obj: any, prefix: string): Record<string, any> => {
@@ -46,7 +48,7 @@ const serializeObject = (obj: any, prefix: string): Record<string, any> => {
   return params;
 };
 
-interface FetchManyEntitiesParams {
+interface FetchManyEntitiesParams extends SpaceReputationContextParams {
   page?: number;
   limit?: number;
   sortBy?: EntityListSortByOptions;
@@ -65,13 +67,6 @@ interface FetchManyEntitiesParams {
   locationFilters?: LocationFilters | null;
   metadataFilters?: MetadataFilters | null;
   include?: EntityIncludeParam;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchManyEntities(): (params?: FetchManyEntitiesParams) => Promise<PaginatedResponse<Entity>> {
@@ -97,8 +92,14 @@ function useFetchManyEntities(): (params?: FetchManyEntitiesParams) => Promise<P
       if (params?.spaceId) queryParams.spaceId = params.spaceId;
       if (params?.userId) queryParams.userId = params.userId;
       if (params?.followedOnly !== undefined) queryParams.followedOnly = params.followedOnly;
-      if (params?.spaceReputationId !== undefined) queryParams.spaceReputationId = params.spaceReputationId;
-      if (params?.spaceReputationDescendants !== undefined) queryParams.spaceReputationDescendants = params.spaceReputationDescendants;
+      Object.assign(
+        queryParams,
+        buildSpaceReputationParams({
+          spaceReputation: params?.spaceReputation,
+          spaceReputationId: params?.spaceReputationId,
+          spaceReputationDescendants: params?.spaceReputationDescendants,
+        })
+      );
 
       if (params?.include) {
         queryParams.include = Array.isArray(params.include)

--- a/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.test.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.test.tsx
@@ -55,6 +55,63 @@ describe("useFetchManyEntitiesWrapper", () => {
     expect(calls[1].config?.params).toMatchObject({ page: 2 });
   });
 
+  it("forwards the spaceReputation OBJECT form as flat params on BOTH page 1 and load-more", async () => {
+    // Regression guard: the load-more path previously forwarded only the
+    // deprecated flat props and dropped the new `spaceReputation` object, so a
+    // caller on the object form got correct reputation on page 1 then a silent
+    // no-op on every load-more page. Exercise the real load-more flow and assert
+    // page 2 carries the same flat `spaceReputationId`/`spaceReputationDescendants`
+    // the object flattens to — never dropped, never bracketed.
+    const firstEntity = makeEntity({ id: "entity-1" });
+    const secondEntity = makeEntity({ id: "entity-2" });
+
+    const { result, axiosPrivate } = renderHookWithAxios(
+      () =>
+        useFetchManyEntitiesWrapper({
+          spaceReputation: { spaceId: "space-7", includeDescendants: true },
+        }),
+      {
+        beforeRender: ({ axiosPrivate }) =>
+          axiosPrivate.mockResponse("get", makePage([firstEntity], true)),
+      },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    axiosPrivate.mockResponse("get", makePage([secondEntity], false));
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.hasMore).toBe(false));
+
+    const calls = axiosPrivate.calls("get");
+    expect(calls).toHaveLength(2);
+
+    const expectFlatReputation = (params: Record<string, unknown> | undefined) => {
+      expect(params).toMatchObject({
+        spaceReputationId: "space-7",
+        spaceReputationDescendants: true,
+      });
+      // The object must NOT survive into the serialized params (bracket-leak /
+      // `[object Object]` would silently no-op on the server).
+      expect(params).not.toHaveProperty("spaceReputation");
+      const qs = new URLSearchParams(
+        Object.entries(params ?? {}).map(([k, v]) => [k, String(v)]),
+      ).toString();
+      expect(qs).toContain("spaceReputationId=space-7");
+      expect(qs).not.toContain("spaceReputation%5B");
+      expect(qs).not.toContain("spaceReputation[");
+    };
+
+    // Page 1 (reset path) and page 2 (load-more path) must be identical.
+    expect(calls[0].config?.params).toMatchObject({ page: 1 });
+    expectFlatReputation(calls[0].config?.params as Record<string, unknown>);
+    expect(calls[1].config?.params).toMatchObject({ page: 2 });
+    expectFlatReputation(calls[1].config?.params as Record<string, unknown>);
+  });
+
   it("resets to page 1 and refetches when the sort options change", async () => {
     const { result, axiosPrivate } = renderHookWithAxios(
       () => useFetchManyEntitiesWrapper({}),

--- a/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
+++ b/packages/core/src/hooks/entities/useFetchManyEntitiesWrapper.tsx
@@ -10,8 +10,9 @@ import { LocationFilters } from "../../interfaces/entity-filters/LocationFilters
 import { MetadataFilters } from "../../interfaces/entity-filters/MetadataFilters";
 import useFetchManyEntities from "./useFetchManyEntities";
 import { handleError } from "../../utils/handleError";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
 
-export interface UseFetchManyEntitiesWrapperProps {
+export interface UseFetchManyEntitiesWrapperProps extends SpaceReputationContextParams {
   userId?: string | null;
   limit?: number;
   sourceId?: string | null;
@@ -29,13 +30,6 @@ export interface UseFetchManyEntitiesWrapperProps {
   attachmentsFilters?: AttachmentsFilters | null;
   locationFilters?: LocationFilters | null;
   metadataFilters?: MetadataFilters | null;
-  /**
-   * Opt into per-row `spaceReputation` on embedded authors. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseFetchManyEntitiesWrapperValues {
@@ -74,9 +68,16 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
+    spaceReputation,
     spaceReputationId,
     spaceReputationDescendants,
   } = props;
+
+  // Forwarded to the leaf fetcher, which flattens it via
+  // buildSpaceReputationParams before it reaches the serializer.
+  const reputation = { spaceReputation, spaceReputationId, spaceReputationDescendants };
+  const reputationKey = JSON.stringify(reputation);
+
   const fetchManyEntities = useFetchManyEntities();
 
   const loading = useRef(true);
@@ -121,8 +122,7 @@ function useFetchManyEntitiesWrapper(
         attachmentsFilters,
         locationFilters,
         metadataFilters,
-        spaceReputationId,
-        spaceReputationDescendants,
+        ...reputation,
       });
 
       if (response) {
@@ -156,9 +156,8 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
-    spaceReputationId,
-    spaceReputationDescendants,
-  ]);
+    reputationKey,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadMore = () => {
     if (loading.current || !hasMore.current) return;
@@ -196,8 +195,7 @@ function useFetchManyEntitiesWrapper(
           attachmentsFilters,
           locationFilters,
           metadataFilters,
-          spaceReputationId,
-          spaceReputationDescendants,
+          ...reputation,
         });
 
         if (response) {
@@ -238,9 +236,8 @@ function useFetchManyEntitiesWrapper(
     attachmentsFilters,
     locationFilters,
     metadataFilters,
-    spaceReputationId,
-    spaceReputationDescendants,
-  ]);
+    reputationKey,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     entities,

--- a/packages/core/src/hooks/entity-lists/spaceReputationSerialization.test.tsx
+++ b/packages/core/src/hooks/entity-lists/spaceReputationSerialization.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, cleanup } from "@testing-library/react";
+
+import {
+  renderHookWithStore,
+  stubFetchMock,
+  unstubFetchMock,
+  jsonResponse,
+  type FetchMockHandle,
+} from "../../test-utils";
+import { useEntityListActions } from "./useEntityListActions";
+
+/**
+ * Serialization regression guard for the entity-lists path (Task 2.4b).
+ *
+ * The entity-lists path is a special case: it persists params in flat Redux
+ * state and serializes via RTK Query's `fetchBaseQuery` (NOT axios). Its
+ * `serializeObject` only runs for keys ending in `Filters`, so a stray
+ * `spaceReputation` OBJECT on `spaceReputationId`/the params would stringify to
+ * `[object Object]` and silently no-op. The object is flattened at the
+ * `useEntityListActions` input boundary precisely to avoid this.
+ *
+ * `stubFetchMock().calls()` returns the real `Request.url` produced by
+ * `fetchBaseQuery`, so we assert on the ACTUAL serialized query string.
+ */
+
+let fetchHandle: FetchMockHandle;
+
+beforeEach(() => {
+  fetchHandle = stubFetchMock(async () => jsonResponse({}, 404));
+});
+
+afterEach(() => {
+  cleanup();
+  unstubFetchMock();
+});
+
+function okPage() {
+  return jsonResponse({
+    data: [],
+    pagination: { page: 1, pageSize: 10, totalPages: 0, totalItems: 0, hasMore: false },
+  });
+}
+
+describe("entity-lists spaceReputation serialization regression guard", () => {
+  it("a list configured via the OBJECT form serializes to a flat spaceReputationId query", async () => {
+    fetchHandle.fetchMock.mockResolvedValueOnce(okPage());
+    const { result } = renderHookWithStore(() => useEntityListActions(), {
+      projectId: "test-project",
+    });
+
+    await act(async () => {
+      await result.current.fetchEntities("feed", {
+        page: 1,
+        sortBy: "hot",
+        limit: 10,
+        spaceReputation: { spaceId: "space-7", includeDescendants: true },
+      });
+    });
+
+    const url = new URL(fetchHandle.calls()[0].url);
+    // Flat keys present with the object's values.
+    expect(url.searchParams.get("spaceReputationId")).toBe("space-7");
+    expect(url.searchParams.get("spaceReputationDescendants")).toBe("true");
+    // The object must NOT have leaked — never bracketed, never `[object Object]`.
+    expect(url.searchParams.has("spaceReputation")).toBe(false);
+    expect(url.searchParams.has("spaceReputation[spaceId]")).toBe(false);
+    expect(url.search).not.toContain("spaceReputation%5B");
+    expect(url.search).not.toContain("%5Bobject+Object%5D");
+    expect(url.search).not.toContain("[object Object]");
+  });
+
+  it("the equivalent FLAT form serializes to the same flat query", async () => {
+    fetchHandle.fetchMock.mockResolvedValueOnce(okPage());
+    const { result } = renderHookWithStore(() => useEntityListActions(), {
+      projectId: "test-project",
+    });
+
+    await act(async () => {
+      await result.current.fetchEntities("feed", {
+        page: 1,
+        sortBy: "hot",
+        limit: 10,
+        spaceReputationId: "space-7",
+        spaceReputationDescendants: true,
+      });
+    });
+
+    const url = new URL(fetchHandle.calls()[0].url);
+    expect(url.searchParams.get("spaceReputationId")).toBe("space-7");
+    expect(url.searchParams.get("spaceReputationDescendants")).toBe("true");
+  });
+});

--- a/packages/core/src/hooks/entity-lists/useEntityList.ts
+++ b/packages/core/src/hooks/entity-lists/useEntityList.ts
@@ -175,6 +175,9 @@ function useEntityList({
           spaceId: configWithDefaults.spaceId,
           limit: configWithDefaults.limit,
           include: configWithDefaults.include,
+          // Object form (primary) + deprecated flat props; flattened downstream
+          // by useEntityListActions before reaching the serializer.
+          spaceReputation: configWithDefaults.spaceReputation,
           spaceReputationId: configWithDefaults.spaceReputationId,
           spaceReputationDescendants: configWithDefaults.spaceReputationDescendants,
         };
@@ -261,6 +264,7 @@ function useEntityList({
             sourceId: currentConfig.sourceId,
             spaceId: currentConfig.spaceId,
             include: currentConfig.include,
+            spaceReputation: currentConfig.spaceReputation,
             spaceReputationId: currentConfig.spaceReputationId,
             spaceReputationDescendants: currentConfig.spaceReputationDescendants,
           });

--- a/packages/core/src/hooks/entity-lists/useEntityListActions.ts
+++ b/packages/core/src/hooks/entity-lists/useEntityListActions.ts
@@ -24,6 +24,8 @@ import type { TitleFilters } from "../../interfaces/entity-filters/TitleFilters"
 import type { ContentFilters } from "../../interfaces/entity-filters/ContentFilters";
 import type { AttachmentsFilters } from "../../interfaces/entity-filters/AttachmentsFilters";
 import type { KeywordsFilters } from "../../interfaces/entity-filters/KeywordsFilters";
+import type { SpaceReputationContextObject } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
 interface FetchEntitiesOptions {
   page: number;
@@ -50,7 +52,14 @@ interface FetchEntitiesOptions {
   spaceId?: string | null;
   limit: number;
   include?: EntityIncludeParam | null;
+  /**
+   * Primary form. Flattened to `spaceReputationId`/`spaceReputationDescendants`
+   * before it reaches the serializer.
+   */
+  spaceReputation?: SpaceReputationContextObject;
+  /** @deprecated Use `spaceReputation` instead. */
   spaceReputationId?: string | null;
+  /** @deprecated Use `spaceReputation.includeDescendants` instead. */
   spaceReputationDescendants?: boolean | null;
 }
 
@@ -112,6 +121,14 @@ export function useEntityListActions(): UseEntityListActionsValues {
 
       dispatch(setEntityListLoading({ listId, loading: true }));
 
+      // Normalize the reputation params at this input boundary so the
+      // `spaceReputation` object never reaches RTK Query's serializer.
+      const reputationParams = buildSpaceReputationParams({
+        spaceReputation: options.spaceReputation,
+        spaceReputationId: options.spaceReputationId,
+        spaceReputationDescendants: options.spaceReputationDescendants,
+      });
+
       try {
         const result = await triggerFetchEntities({
           projectId,
@@ -133,8 +150,8 @@ export function useEntityListActions(): UseEntityListActionsValues {
           contentFilters: options.contentFilters,
           attachmentsFilters: options.attachmentsFilters,
           include: options.include,
-          spaceReputationId: options.spaceReputationId,
-          spaceReputationDescendants: options.spaceReputationDescendants,
+          spaceReputationId: reputationParams.spaceReputationId,
+          spaceReputationDescendants: reputationParams.spaceReputationDescendants,
         }).unwrap();
 
         if (result) {

--- a/packages/core/src/hooks/reactions/useFetchCommentReactions.tsx
+++ b/packages/core/src/hooks/reactions/useFetchCommentReactions.tsx
@@ -3,20 +3,15 @@ import { Reaction, ReactionType } from "../../interfaces/models/Reaction";
 import { PaginatedResponse } from "../../interfaces/PaginatedResponse";
 import useProject from "../projects/useProject";
 import axios from "../../config/axios";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchCommentReactionsProps {
+export interface FetchCommentReactionsProps extends SpaceReputationContextParams {
   commentId: string;
   page: number;
   limit?: number;
   reactionType?: ReactionType;
   sortDir?: "asc" | "desc";
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Promise<PaginatedResponse<Reaction>> {
@@ -24,7 +19,7 @@ function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Prom
 
   const fetchCommentReactions = useCallback(
     async (props: FetchCommentReactionsProps): Promise<PaginatedResponse<Reaction>> => {
-      const { commentId, page, limit = 20, reactionType, sortDir = "desc", spaceReputationId, spaceReputationDescendants } = props;
+      const { commentId, page, limit = 20, reactionType, sortDir = "desc", spaceReputation, spaceReputationId, spaceReputationDescendants } = props;
 
       if (page === 0) {
         throw new Error("Can't fetch reactions with page 0");
@@ -46,13 +41,16 @@ function useFetchCommentReactions(): (props: FetchCommentReactionsProps) => Prom
         page,
         limit,
         sortDir,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
 
       if (reactionType) {
         params.reactionType = reactionType;
       }
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<PaginatedResponse<Reaction>>(
         `/${projectId}/comments/${commentId}/reactions`,

--- a/packages/core/src/hooks/reactions/useFetchEntityReactions.tsx
+++ b/packages/core/src/hooks/reactions/useFetchEntityReactions.tsx
@@ -3,20 +3,15 @@ import { Reaction, ReactionType } from "../../interfaces/models/Reaction";
 import { PaginatedResponse } from "../../interfaces/PaginatedResponse";
 import useProject from "../projects/useProject";
 import axios from "../../config/axios";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchEntityReactionsProps {
+export interface FetchEntityReactionsProps extends SpaceReputationContextParams {
   entityId: string;
   page: number;
   limit?: number;
   reactionType?: ReactionType;
   sortDir?: "asc" | "desc";
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promise<PaginatedResponse<Reaction>> {
@@ -24,7 +19,7 @@ function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promis
 
   const fetchEntityReactions = useCallback(
     async (props: FetchEntityReactionsProps): Promise<PaginatedResponse<Reaction>> => {
-      const { entityId, page, limit = 20, reactionType, sortDir = "desc", spaceReputationId, spaceReputationDescendants } = props;
+      const { entityId, page, limit = 20, reactionType, sortDir = "desc", spaceReputation, spaceReputationId, spaceReputationDescendants } = props;
 
       if (page === 0) {
         throw new Error("Can't fetch reactions with page 0");
@@ -46,13 +41,16 @@ function useFetchEntityReactions(): (props: FetchEntityReactionsProps) => Promis
         page,
         limit,
         sortDir,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
 
       if (reactionType) {
         params.reactionType = reactionType;
       }
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get<PaginatedResponse<Reaction>>(
         `/${projectId}/entities/${entityId}/reactions`,

--- a/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
+++ b/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
@@ -3,19 +3,13 @@ import useProject from "../../projects/useProject";
 import { EstablishedConnection } from "../../../interfaces/models/Connection";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
+import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
-export interface FetchConnectionsByUserIdParams {
+export interface FetchConnectionsByUserIdParams extends SpaceReputationUserParams {
   userId: string;
   page?: number;
   limit?: number;
-  /**
-   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
-   * by-user-id graph read has no per-row space context.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) => Promise<PaginatedResponse<EstablishedConnection>> {
@@ -25,7 +19,7 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
     async (
       props: FetchConnectionsByUserIdParams
     ): Promise<PaginatedResponse<EstablishedConnection>> => {
-      const { userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants } = props;
+      const { userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants } = props;
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -34,9 +28,15 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
         throw new Error("No user ID was provided");
       }
 
-      const params: Record<string, any> = { page, limit };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        page,
+        limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<PaginatedResponse<EstablishedConnection>>(
         `/users/${userId}/connections`,

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
@@ -3,6 +3,8 @@ import useProject from "../../projects/useProject";
 import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
+import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
 export interface FollowerWithFollowInfo {
   followId: string;
@@ -10,25 +12,17 @@ export interface FollowerWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowersByUserIdParams {
+export interface FetchFollowersByUserIdParams extends SpaceReputationUserParams {
   userId: string;
   page?: number;
   limit?: number;
-  /**
-   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
-   * by-user-id graph read has no per-row space context.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => Promise<PaginatedResponse<FollowerWithFollowInfo>> {
   const { projectId } = useProject();
 
   const fetchFollowersByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants }: FetchFollowersByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowersByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -37,9 +31,15 @@ function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => 
         throw new Error("No projectId available.");
       }
 
-      const params: Record<string, any> = { page, limit };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        page,
+        limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<PaginatedResponse<FollowerWithFollowInfo>>(
         `/${projectId}/users/${userId}/followers`,

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
@@ -3,6 +3,8 @@ import useProject from "../../projects/useProject";
 import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
+import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
 export interface FollowingWithFollowInfo {
   followId: string;
@@ -10,25 +12,17 @@ export interface FollowingWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowingByUserIdParams {
+export interface FetchFollowingByUserIdParams extends SpaceReputationUserParams {
   userId: string;
   page?: number;
   limit?: number;
-  /**
-   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) — this
-   * by-user-id graph read has no per-row space context.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => Promise<PaginatedResponse<FollowingWithFollowInfo>> {
   const { projectId } = useProject();
 
   const fetchFollowingByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20, spaceReputationId, spaceReputationDescendants }: FetchFollowingByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowingByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -37,9 +31,15 @@ function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => 
         throw new Error("No projectId available.");
       }
 
-      const params: Record<string, any> = { page, limit };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        page,
+        limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<PaginatedResponse<FollowingWithFollowInfo>>(
         `/${projectId}/users/${userId}/following`,

--- a/packages/core/src/hooks/reports/useFetchModeratedReports.tsx
+++ b/packages/core/src/hooks/reports/useFetchModeratedReports.tsx
@@ -5,21 +5,16 @@ import { PaginatedResponse } from "../../interfaces/PaginatedResponse";
 import { Entity } from "../../interfaces/models/Entity";
 import { Comment } from "../../interfaces/models/Comment";
 import { Space } from "../../interfaces/models/Space";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchModeratedReportsParams {
+export interface FetchModeratedReportsParams extends SpaceReputationContextParams {
   spaceId?: string;
   targetType?: "comment" | "entity";
   status?: "pending" | "on-hold" | "escalated" | "dismissed" | "actioned";
   sortBy?: "new" | "old";
   page?: number;
   limit?: number;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface ReportUserReport {
@@ -82,6 +77,7 @@ function useFetchModeratedReports(): (params: FetchModeratedReportsParams) => Pr
       sortBy,
       page,
       limit,
+      spaceReputation,
       spaceReputationId,
       spaceReputationDescendants,
     }: FetchModeratedReportsParams) => {
@@ -89,9 +85,19 @@ function useFetchModeratedReports(): (params: FetchModeratedReportsParams) => Pr
         throw new Error("No projectId available.");
       }
 
-      const params: Record<string, any> = { spaceId, targetType, status, sortBy, page, limit };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        spaceId,
+        targetType,
+        status,
+        sortBy,
+        page,
+        limit,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<PaginatedResponse<Report>>(
         `/${projectId}/reports/moderated`,

--- a/packages/core/src/hooks/search/useAskContent.ts
+++ b/packages/core/src/hooks/search/useAskContent.ts
@@ -4,8 +4,10 @@ import { useSublaySelector } from "../../store/hooks";
 import { selectAccessToken } from "../../store/slices/authSlice";
 import { BASE_URL } from "../../config/axios";
 import { ContentSearchResult } from "./useSearchContent";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface UseAskContentProps {
+export interface UseAskContentProps extends SpaceReputationContextParams {
   query: string;
   sourceTypes?: ("entity" | "comment" | "message")[];
   spaceId?: string;
@@ -17,14 +19,6 @@ export interface UseAskContentProps {
   includeChildSpaces?: boolean;
   conversationId?: string;
   limit?: number;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`. Sent as a query param (the server
-   * reads it from the query string, not the request body).
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseAskContentReturn {
@@ -104,7 +98,7 @@ export default function useAskContent(): UseAskContentReturn {
   }, []);
 
   const ask = useCallback(
-    ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseAskContentProps) => {
+    ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputation, spaceReputationId, spaceReputationDescendants }: UseAskContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
@@ -141,10 +135,19 @@ export default function useAskContent(): UseAskContentReturn {
       // spaceReputation opt-in is read from the query string by the server,
       // not the request body — append it to the URL.
       const queryString = (() => {
+        const reputationParams = buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        });
         const sp = new URLSearchParams();
-        if (spaceReputationId !== undefined) sp.set("spaceReputationId", spaceReputationId);
-        if (spaceReputationDescendants !== undefined)
-          sp.set("spaceReputationDescendants", String(spaceReputationDescendants));
+        if (reputationParams.spaceReputationId !== undefined)
+          sp.set("spaceReputationId", reputationParams.spaceReputationId);
+        if (reputationParams.spaceReputationDescendants !== undefined)
+          sp.set(
+            "spaceReputationDescendants",
+            String(reputationParams.spaceReputationDescendants)
+          );
         const s = sp.toString();
         return s ? `?${s}` : "";
       })();

--- a/packages/core/src/hooks/search/useSearchContent.ts
+++ b/packages/core/src/hooks/search/useSearchContent.ts
@@ -5,6 +5,8 @@ import { handleError } from "../../utils/handleError";
 import { Entity } from "../../interfaces/models/Entity";
 import { Comment } from "../../interfaces/models/Comment";
 import { ChatMessage } from "../../interfaces/models/ChatMessage";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
 export interface ContentSearchResult {
   sourceType: "entity" | "comment" | "message";
@@ -12,7 +14,7 @@ export interface ContentSearchResult {
   record: Entity | Comment | ChatMessage;
 }
 
-export interface UseSearchContentProps {
+export interface UseSearchContentProps extends SpaceReputationContextParams {
   query: string;
   sourceTypes?: ("entity" | "comment" | "message")[];
   spaceId?: string;
@@ -24,14 +26,6 @@ export interface UseSearchContentProps {
   includeChildSpaces?: boolean;
   conversationId?: string;
   limit?: number;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`. Sent as a query param (the server
-   * reads it from the query string, not the request body).
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 export interface UseSearchContentReturn {
@@ -51,16 +45,18 @@ export default function useSearchContent(): UseSearchContentReturn {
   const [error, setError] = useState<string | null>(null);
 
   const search = useCallback(
-    async ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputationId, spaceReputationDescendants }: UseSearchContentProps) => {
+    async ({ query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit, spaceReputation, spaceReputationId, spaceReputationDescendants }: UseSearchContentProps) => {
       if (!projectId) return;
       if (!query.trim()) return;
 
       setLoading(true);
       setError(null);
       try {
-        const params: Record<string, any> = {};
-        if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-        if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+        const params: Record<string, any> = buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        });
         const response = await axios.post<ContentSearchResult[]>(
           `/${projectId}/search/content`,
           { query, sourceTypes, spaceId, includeChildSpaces, conversationId, limit },

--- a/packages/core/src/hooks/spaces/useFetchSpaceMembers.tsx
+++ b/packages/core/src/hooks/spaces/useFetchSpaceMembers.tsx
@@ -6,20 +6,15 @@ import {
   SpaceMemberStatus,
 } from "../../interfaces/models/SpaceMember";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchSpaceMembersProps {
+export interface FetchSpaceMembersProps extends SpaceReputationContextParams {
   spaceId: string;
   page?: number;
   limit?: number;
   role?: SpaceMemberRole;
   status?: SpaceMemberStatus;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<SpaceMembersResponse> {
@@ -27,7 +22,7 @@ function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<Spac
   const axios = useAxiosPrivate();
 
   const fetchSpaceMembers = useCallback(
-    async ({ spaceId, page, limit, role, status, spaceReputationId, spaceReputationDescendants }: FetchSpaceMembersProps) => {
+    async ({ spaceId, page, limit, role, status, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchSpaceMembersProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -36,9 +31,17 @@ function useFetchSpaceMembers(): (props: FetchSpaceMembersProps) => Promise<Spac
         throw new Error("Please pass a spaceId");
       }
 
-      const params: Record<string, any> = { page, limit, role, status };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        page,
+        limit,
+        role,
+        status,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<SpaceMembersResponse>(
         `/${projectId}/spaces/${spaceId}/members`,

--- a/packages/core/src/hooks/spaces/useFetchSpaceTeam.tsx
+++ b/packages/core/src/hooks/spaces/useFetchSpaceTeam.tsx
@@ -2,16 +2,11 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import { SpaceTeamResponse } from "../../interfaces/models/SpaceMember";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
+import { SpaceReputationContextParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchSpaceTeamProps {
+export interface FetchSpaceTeamProps extends SpaceReputationContextParams {
   spaceId: string;
-  /**
-   * Opt into per-row `spaceReputation` on embedded users. Accepted forms: a
-   * space `<uuid>`, `"none"`, or `"context"`.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 // Fetches all admins and moderators of a space (no pagination)
@@ -20,7 +15,7 @@ function useFetchSpaceTeam(): (props: FetchSpaceTeamProps) => Promise<SpaceTeamR
   const axios = useAxiosPrivate();
 
   const fetchSpaceTeam = useCallback(
-    async ({ spaceId, spaceReputationId, spaceReputationDescendants }: FetchSpaceTeamProps) => {
+    async ({ spaceId, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchSpaceTeamProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -31,9 +26,13 @@ function useFetchSpaceTeam(): (props: FetchSpaceTeamProps) => Promise<SpaceTeamR
 
       const url = `/${projectId}/spaces/${spaceId}/team`;
 
-      const params: Record<string, any> = {};
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get<SpaceTeamResponse>(url, { params });
 

--- a/packages/core/src/hooks/users/useFetchUser.tsx
+++ b/packages/core/src/hooks/users/useFetchUser.tsx
@@ -3,18 +3,12 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import axios from "../../config/axios";
 import { User, UserIncludeParam } from "../../interfaces/models/User";
+import { SpaceReputationUserParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchUserProps {
+export interface FetchUserProps extends SpaceReputationUserParams {
   userId: string;
   include?: UserIncludeParam;
-  /**
-   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
-   * bare user lookup — there is no row context to derive a space from.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUser(): (props: FetchUserProps) => Promise<User> {
@@ -24,6 +18,7 @@ function useFetchUser(): (props: FetchUserProps) => Promise<User> {
     async ({
       userId,
       include,
+      spaceReputation,
       spaceReputationId,
       spaceReputationDescendants,
     }: FetchUserProps) => {
@@ -37,9 +32,12 @@ function useFetchUser(): (props: FetchUserProps) => Promise<User> {
 
       const params: Record<string, any> = {
         include: Array.isArray(include) ? include.join(",") : include,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/users/${userId}`, {
         params,

--- a/packages/core/src/hooks/users/useFetchUserByForeignId.tsx
+++ b/packages/core/src/hooks/users/useFetchUserByForeignId.tsx
@@ -3,18 +3,12 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import axios from "../../config/axios";
 import { User, UserIncludeParam } from "../../interfaces/models/User";
+import { SpaceReputationUserParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchUserByForeignIdProps {
+export interface FetchUserByForeignIdProps extends SpaceReputationUserParams {
   foreignId: string;
   include?: UserIncludeParam;
-  /**
-   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
-   * bare user lookup — there is no row context to derive a space from.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promise<User> {
@@ -24,6 +18,7 @@ function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promis
     async ({
       foreignId,
       include,
+      spaceReputation,
       spaceReputationId,
       spaceReputationDescendants,
     }: FetchUserByForeignIdProps) => {
@@ -38,9 +33,12 @@ function useFetchUserByForeignId(): (props: FetchUserByForeignIdProps) => Promis
       const params: Record<string, any> = {
         foreignId,
         include: Array.isArray(include) ? include.join(",") : include,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/users/by-foreign-id`, {
         params,

--- a/packages/core/src/hooks/users/useFetchUserByUsername.tsx
+++ b/packages/core/src/hooks/users/useFetchUserByUsername.tsx
@@ -3,18 +3,12 @@ import { useCallback } from "react";
 import useProject from "../projects/useProject";
 import axios from "../../config/axios";
 import { User, UserIncludeParam } from "../../interfaces/models/User";
+import { SpaceReputationUserParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchUserByUsernameProps {
+export interface FetchUserByUsernameProps extends SpaceReputationUserParams {
   username: string;
   include?: UserIncludeParam;
-  /**
-   * Opt into `spaceReputation` on the returned user. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
-   * bare user lookup — there is no row context to derive a space from.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<User> {
@@ -24,6 +18,7 @@ function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<
     async ({
       username,
       include,
+      spaceReputation,
       spaceReputationId,
       spaceReputationDescendants,
     }: FetchUserByUsernameProps) => {
@@ -38,9 +33,12 @@ function useFetchUserByUsername(): (props: FetchUserByUsernameProps) => Promise<
       const params: Record<string, any> = {
         username,
         include: Array.isArray(include) ? include.join(",") : include,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
       };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
 
       const response = await axios.get(`/${projectId}/users/by-username`, {
         params,

--- a/packages/core/src/hooks/users/useFetchUserSuggestions.tsx
+++ b/packages/core/src/hooks/users/useFetchUserSuggestions.tsx
@@ -2,17 +2,11 @@ import { useCallback } from "react";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
 import useProject from "../projects/useProject";
 import { User } from "../../interfaces/models/User";
+import { SpaceReputationUserParams } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
-export interface FetchUserSuggestionsProps {
+export interface FetchUserSuggestionsProps extends SpaceReputationUserParams {
   query: string;
-  /**
-   * Opt into `spaceReputation` on the returned users. Accepted forms: a space
-   * `<uuid>` or `"none"`. `"context"` is rejected by the server (400) on this
-   * bare user lookup — there is no row context to derive a space from.
-   */
-  spaceReputationId?: string;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
-  spaceReputationDescendants?: boolean;
 }
 
 function useFetchUserSuggestions(): (props: FetchUserSuggestionsProps) => Promise<User[]> {
@@ -20,14 +14,19 @@ function useFetchUserSuggestions(): (props: FetchUserSuggestionsProps) => Promis
   const { projectId } = useProject();
 
   const fetchUserSuggestions = useCallback(
-    async ({ query, spaceReputationId, spaceReputationDescendants }: FetchUserSuggestionsProps) => {
+    async ({ query, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchUserSuggestionsProps) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
 
-      const params: Record<string, any> = { query };
-      if (spaceReputationId !== undefined) params.spaceReputationId = spaceReputationId;
-      if (spaceReputationDescendants !== undefined) params.spaceReputationDescendants = spaceReputationDescendants;
+      const params: Record<string, any> = {
+        query,
+        ...buildSpaceReputationParams({
+          spaceReputation,
+          spaceReputationId,
+          spaceReputationDescendants,
+        }),
+      };
 
       const response = await axios.get(`/${projectId}/users/suggestions`, {
         params,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,11 @@ export {
   getApiBaseUrl,
   getEnvVar,
 } from "./utils/env";
+export {
+  buildSpaceReputationParams,
+  type BuildSpaceReputationParamsInput,
+  type SpaceReputationFlatParams,
+} from "./utils/spaceReputationParams";
 
 // Constants
 export { reportReasons } from "./constants/reportReasons";
@@ -624,6 +629,12 @@ export type {
   SpaceListFilters,
 } from "./interfaces/SpaceListSortByOptions";
 export type { SpaceBreadcrumb } from "./interfaces/SpaceBreadcrumb";
+export type {
+  SpaceReputationContextParams,
+  SpaceReputationUserParams,
+  SpaceReputationContextObject,
+  SpaceReputationUserObject,
+} from "./interfaces/SpaceReputation";
 export type {
   Rule,
   FetchManyRulesResponse,

--- a/packages/core/src/interfaces/SpaceReputation.ts
+++ b/packages/core/src/interfaces/SpaceReputation.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared optional params for opting embedded/returned users into a
+ * space-scoped reputation value (`spaceReputation`; see
+ * {@link import("./models/User").UserFull}).
+ *
+ * The relationship is expressed as a single `spaceReputation` object —
+ * `{ spaceId, includeDescendants? }` — rather than the two flat props it
+ * replaces, because the two always travel together and `includeDescendants`
+ * is only meaningful alongside an explicit `spaceId`.
+ *
+ * Two variants exist because the server accepts a different value set per
+ * endpoint class:
+ * - {@link SpaceReputationContextParams} — context endpoints (entities,
+ *   comments, chat, spaces team/members, search, reports). Accept
+ *   `<uuid> | "none" | "context"`.
+ * - {@link SpaceReputationUserParams} — user-direct endpoints (the `users`
+ *   module). Accept `<uuid> | "none"` only; `"context"` is rejected (400).
+ *
+ * Both variants also keep the now-deprecated flat props
+ * (`spaceReputationId` / `spaceReputationDescendants`) so existing callers
+ * keep working unchanged. When both forms are supplied the object wins.
+ */
+
+/**
+ * The space-reputation object for context endpoints (entities, comments,
+ * chat, spaces team/members, search, reports).
+ */
+export interface SpaceReputationContextObject {
+  /**
+   * Which space's reputation to attach to the returned/embedded user(s).
+   * Accepted forms:
+   * - a space `<uuid>` — reputation scoped to that specific space
+   * - `"none"` — the user's global, non-space reputation
+   * - `"context"` — reputation scoped to each row's own space (per-row)
+   */
+  spaceId: string | "none" | "context";
+  /**
+   * Include reputation accrued in descendant spaces. Only honored when
+   * `spaceId` is an explicit `<uuid>`; ignored for `"none"` and disallowed
+   * (not applicable) with `"context"`.
+   */
+  includeDescendants?: boolean;
+}
+
+/**
+ * The space-reputation object for user-direct endpoints. Same as
+ * {@link SpaceReputationContextObject} but `"context"` is rejected by the
+ * server (400) on these routes — only a `<uuid>` or `"none"` is valid.
+ */
+export interface SpaceReputationUserObject {
+  /**
+   * Which space's reputation to attach to the returned user(s).
+   * Accepted forms:
+   * - a space `<uuid>` — reputation scoped to that specific space
+   * - `"none"` — the user's global, non-space reputation
+   *
+   * Note: `"context"` is rejected by the server (400) on user-direct routes;
+   * pass an explicit `<uuid>` or `"none"` here.
+   */
+  spaceId: string | "none";
+  /**
+   * Include reputation accrued in descendant spaces. Only honored when
+   * `spaceId` is an explicit `<uuid>`; ignored for `"none"`.
+   */
+  includeDescendants?: boolean;
+}
+
+/**
+ * Space-reputation params for endpoints whose controllers enrich users from
+ * the *current request context* (entities, comments, chat, spaces
+ * team/members, search, reports).
+ */
+export interface SpaceReputationContextParams {
+  /**
+   * Opt the returned/embedded user(s) into a space-scoped `spaceReputation`.
+   * This is the primary form; it supersedes the deprecated flat props below.
+   */
+  spaceReputation?: SpaceReputationContextObject;
+  /**
+   * Which space's reputation to attach. Accepts a space `<uuid>`, `"none"`
+   * (global reputation), or `"context"` (per-row).
+   *
+   * @deprecated Use `spaceReputation: { spaceId, includeDescendants? }`
+   * instead. Still accepted for backward compatibility; ignored when the
+   * `spaceReputation` object is supplied.
+   */
+  spaceReputationId?: string;
+  /**
+   * Include reputation accrued in descendant spaces. Only honored when
+   * `spaceReputationId` is an explicit `<uuid>`.
+   *
+   * @deprecated Use `spaceReputation.includeDescendants` instead. Still
+   * accepted for backward compatibility; ignored when the `spaceReputation`
+   * object is supplied.
+   */
+  spaceReputationDescendants?: boolean;
+}
+
+/**
+ * Space-reputation params for user-direct endpoints (e.g. `/users/:id`,
+ * `/users/by-username`, `/users/:id/followers`). Same fields as
+ * {@link SpaceReputationContextParams}, but `"context"` is rejected by the
+ * server (400) on these routes — only a `<uuid>` or `"none"` is valid.
+ */
+export interface SpaceReputationUserParams {
+  /**
+   * Opt the returned user(s) into a space-scoped `spaceReputation`.
+   * This is the primary form; it supersedes the deprecated flat props below.
+   */
+  spaceReputation?: SpaceReputationUserObject;
+  /**
+   * Which space's reputation to attach. Accepts a space `<uuid>` or `"none"`
+   * (global reputation). `"context"` is rejected by the server (400) here.
+   *
+   * @deprecated Use `spaceReputation: { spaceId, includeDescendants? }`
+   * instead. Still accepted for backward compatibility; ignored when the
+   * `spaceReputation` object is supplied.
+   */
+  spaceReputationId?: string;
+  /**
+   * Include reputation accrued in descendant spaces. Only honored when
+   * `spaceReputationId` is an explicit `<uuid>`.
+   *
+   * @deprecated Use `spaceReputation.includeDescendants` instead. Still
+   * accepted for backward compatibility; ignored when the `spaceReputation`
+   * object is supplied.
+   */
+  spaceReputationDescendants?: boolean;
+}

--- a/packages/core/src/store/slices/entityListsSlice.ts
+++ b/packages/core/src/store/slices/entityListsSlice.ts
@@ -14,6 +14,8 @@ import { TitleFilters } from "../../interfaces/entity-filters/TitleFilters";
 import { ContentFilters } from "../../interfaces/entity-filters/ContentFilters";
 import { AttachmentsFilters } from "../../interfaces/entity-filters/AttachmentsFilters";
 import { KeywordsFilters } from "../../interfaces/entity-filters/KeywordsFilters";
+import { SpaceReputationContextObject } from "../../interfaces/SpaceReputation";
+import { buildSpaceReputationParams } from "../../utils/spaceReputationParams";
 
 // Individual entity list state
 export interface EntityListState {
@@ -120,11 +122,26 @@ export interface EntityListConfig {
   limit?: number;
   include?: EntityIncludeParam | null;
   /**
+   * Opt the embedded authors into a space-scoped `spaceReputation`. This is the
+   * primary form; it supersedes the deprecated flat props below. Normalized to
+   * the flat `spaceReputationId`/`spaceReputationDescendants` pair before it is
+   * stored in slice state (the persisted shape stays flat).
+   */
+  spaceReputation?: SpaceReputationContextObject;
+  /**
    * Opt into per-row `spaceReputation` on embedded authors. Accepted forms: a
    * space `<uuid>`, `"none"`, or `"context"`.
+   *
+   * @deprecated Use `spaceReputation: { spaceId, includeDescendants? }`
+   * instead. Still accepted; ignored when the `spaceReputation` object is supplied.
    */
   spaceReputationId?: string | null;
-  /** Only honored with an explicit `<uuid>` `spaceReputationId`. */
+  /**
+   * Only honored with an explicit `<uuid>` `spaceReputationId`.
+   *
+   * @deprecated Use `spaceReputation.includeDescendants` instead. Still
+   * accepted; ignored when the `spaceReputation` object is supplied.
+   */
   spaceReputationDescendants?: boolean | null;
 }
 
@@ -255,11 +272,25 @@ export const entityListsSlice = createSlice({
         if (config.include !== undefined) {
           list.include = config.include;
         }
-        if (config.spaceReputationId !== undefined) {
-          list.spaceReputationId = config.spaceReputationId;
-        }
-        if (config.spaceReputationDescendants !== undefined) {
-          list.spaceReputationDescendants = config.spaceReputationDescendants;
+        // Normalize the reputation params at this input boundary so the
+        // `spaceReputation` object never reaches the persisted (flat) state or
+        // the serializer. When the object form is supplied it wins; an absent
+        // key inside it clears the corresponding flat field to `null`.
+        if (config.spaceReputation !== undefined) {
+          const flat = buildSpaceReputationParams({
+            spaceReputation: config.spaceReputation,
+          });
+          list.spaceReputationId = flat.spaceReputationId ?? null;
+          list.spaceReputationDescendants =
+            flat.spaceReputationDescendants ?? null;
+        } else {
+          // Flat form (back-compat). `null` stays meaningful ("explicitly cleared").
+          if (config.spaceReputationId !== undefined) {
+            list.spaceReputationId = config.spaceReputationId;
+          }
+          if (config.spaceReputationDescendants !== undefined) {
+            list.spaceReputationDescendants = config.spaceReputationDescendants;
+          }
         }
       }
 

--- a/packages/core/src/utils/spaceReputationParams.test.ts
+++ b/packages/core/src/utils/spaceReputationParams.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+import { buildSpaceReputationParams } from "./spaceReputationParams";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildSpaceReputationParams", () => {
+  describe("object form vs equivalent flat form", () => {
+    it("produces identical output for a uuid + descendants", () => {
+      const fromObject = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "abc-123", includeDescendants: true },
+      });
+      const fromFlat = buildSpaceReputationParams({
+        spaceReputationId: "abc-123",
+        spaceReputationDescendants: true,
+      });
+
+      expect(fromObject).toEqual({
+        spaceReputationId: "abc-123",
+        spaceReputationDescendants: true,
+      });
+      expect(fromObject).toEqual(fromFlat);
+    });
+
+    it("produces identical output for `none` with no descendants", () => {
+      const fromObject = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "none" },
+      });
+      const fromFlat = buildSpaceReputationParams({
+        spaceReputationId: "none",
+      });
+
+      expect(fromObject).toEqual({ spaceReputationId: "none" });
+      expect(fromObject).toEqual(fromFlat);
+    });
+
+    it("produces identical output for `context`", () => {
+      const fromObject = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "context" },
+      });
+      const fromFlat = buildSpaceReputationParams({
+        spaceReputationId: "context",
+      });
+
+      expect(fromObject).toEqual({ spaceReputationId: "context" });
+      expect(fromObject).toEqual(fromFlat);
+    });
+  });
+
+  describe("output is always flat (never bracketed/nested)", () => {
+    it("returns only the two flat keys", () => {
+      const result = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "abc-123", includeDescendants: false },
+      });
+
+      expect(Object.keys(result).sort()).toEqual([
+        "spaceReputationDescendants",
+        "spaceReputationId",
+      ]);
+      expect(result).not.toHaveProperty("spaceReputation");
+    });
+
+    it("omits keys when unset (empty input → empty output)", () => {
+      expect(buildSpaceReputationParams({})).toEqual({});
+    });
+  });
+
+  describe("precedence — object wins when key present", () => {
+    it("a full object overrides supplied flat props", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "from-object", includeDescendants: true },
+        spaceReputationId: "from-flat",
+        spaceReputationDescendants: false,
+      });
+
+      expect(result).toEqual({
+        spaceReputationId: "from-object",
+        spaceReputationDescendants: true,
+      });
+    });
+
+    it("an empty object `{}` suppresses the flat props", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = buildSpaceReputationParams({
+        // @ts-expect-error — intentionally partial: presence of the key alone wins
+        spaceReputation: {},
+        spaceReputationId: "from-flat",
+        spaceReputationDescendants: true,
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it("a partial object (no includeDescendants) suppresses the flat descendants prop", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = buildSpaceReputationParams({
+        spaceReputation: { spaceId: "abc-123" },
+        spaceReputationDescendants: true,
+      });
+
+      expect(result).toEqual({ spaceReputationId: "abc-123" });
+    });
+
+    it("falls back to flat props when the object key is absent", () => {
+      const result = buildSpaceReputationParams({
+        spaceReputationId: "abc-123",
+        spaceReputationDescendants: true,
+      });
+
+      expect(result).toEqual({
+        spaceReputationId: "abc-123",
+        spaceReputationDescendants: true,
+      });
+    });
+  });
+
+  describe("dev warning when both forms supplied", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+
+    it("fires once, never throws, and warns only when both forms are present", async () => {
+      vi.resetModules();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // Fresh module so the module-level "warned once" flag is reset.
+      const { buildSpaceReputationParams: build } = await import(
+        "./spaceReputationParams"
+      );
+
+      // First call with both forms → warns.
+      expect(() =>
+        build({
+          spaceReputation: { spaceId: "abc-123" },
+          spaceReputationId: "from-flat",
+        })
+      ).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Second call with both forms → does NOT warn again (one-time).
+      build({
+        spaceReputation: { spaceId: "def-456" },
+        spaceReputationDescendants: true,
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not warn when only one form is supplied", async () => {
+      vi.resetModules();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { buildSpaceReputationParams: build } = await import(
+        "./spaceReputationParams"
+      );
+
+      build({ spaceReputation: { spaceId: "abc-123" } });
+      build({ spaceReputationId: "abc-123" });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn in production", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.resetModules();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { buildSpaceReputationParams: build } = await import(
+        "./spaceReputationParams"
+      );
+
+      build({
+        spaceReputation: { spaceId: "abc-123" },
+        spaceReputationId: "from-flat",
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("null flat input is treated as unset", () => {
+    it("omits params when flat inputs are null", () => {
+      expect(
+        buildSpaceReputationParams({
+          spaceReputationId: null,
+          spaceReputationDescendants: null,
+        })
+      ).toEqual({});
+    });
+
+    it("keeps a real flat value while omitting a null sibling", () => {
+      expect(
+        buildSpaceReputationParams({
+          spaceReputationId: "abc-123",
+          spaceReputationDescendants: null,
+        })
+      ).toEqual({ spaceReputationId: "abc-123" });
+    });
+
+    it("a null flat input does not count as 'both forms' (no warning) when an object is present", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.resetModules();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { buildSpaceReputationParams: build } = await import(
+        "./spaceReputationParams"
+      );
+
+      build({
+        spaceReputation: { spaceId: "abc-123" },
+        spaceReputationId: null,
+        spaceReputationDescendants: null,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    });
+  });
+});

--- a/packages/core/src/utils/spaceReputationParams.ts
+++ b/packages/core/src/utils/spaceReputationParams.ts
@@ -1,0 +1,103 @@
+import { isProduction } from "./env";
+
+/**
+ * Input accepted by {@link buildSpaceReputationParams}: either the new
+ * `spaceReputation` object or the deprecated flat props.
+ *
+ * The flat inputs accept `null` (in addition to `undefined`) because the
+ * entity-lists path persists them as `string | null` / `boolean | null` and
+ * passes `null` through to mean "explicitly unset". `null` is treated as unset.
+ */
+export interface BuildSpaceReputationParamsInput {
+  spaceReputation?: {
+    spaceId: string | "none" | "context";
+    includeDescendants?: boolean;
+  };
+  /**
+   * @deprecated Pass `spaceReputation` instead. Accepted for back-compat.
+   */
+  spaceReputationId?: string | null;
+  /**
+   * @deprecated Pass `spaceReputation` instead. Accepted for back-compat.
+   */
+  spaceReputationDescendants?: boolean | null;
+}
+
+/**
+ * Flat output handed to the query-string serializer. Both keys are omitted
+ * when unset — never bracketed, never nested.
+ */
+export interface SpaceReputationFlatParams {
+  spaceReputationId?: string;
+  spaceReputationDescendants?: boolean;
+}
+
+let bothFormsWarned = false;
+
+/**
+ * Normalize the `spaceReputation` object or the deprecated flat props down to
+ * the flat query params the server understands
+ * (`spaceReputationId` / `spaceReputationDescendants`).
+ *
+ * Rules:
+ * - **Object wins when present.** "Present" means the `spaceReputation` key was
+ *   supplied at all (`spaceReputation !== undefined`) — even `{}` or a partial
+ *   object suppresses the flat props, because supplying the key is an explicit
+ *   opt-in to the new form.
+ * - When **both** the object and a flat prop are supplied, the object wins and
+ *   a one-time dev-only `console.warn` fires (never throws).
+ * - The flat inputs tolerate `null` (treated as unset → param omitted).
+ * - Output keys are omitted when unset; the result is always the two flat keys,
+ *   never a bracketed/nested object.
+ */
+export function buildSpaceReputationParams(
+  input: BuildSpaceReputationParamsInput
+): SpaceReputationFlatParams {
+  const { spaceReputation, spaceReputationId, spaceReputationDescendants } =
+    input;
+
+  const objectPresent = spaceReputation !== undefined;
+  const flatPresent =
+    (spaceReputationId !== undefined && spaceReputationId !== null) ||
+    (spaceReputationDescendants !== undefined &&
+      spaceReputationDescendants !== null);
+
+  if (objectPresent && flatPresent && !bothFormsWarned && !isProduction()) {
+    bothFormsWarned = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[Sublay] Both `spaceReputation` and the deprecated flat props " +
+        "(`spaceReputationId` / `spaceReputationDescendants`) were supplied. " +
+        "The `spaceReputation` object takes precedence; the flat props are ignored. " +
+        "Remove the flat props — they are deprecated."
+    );
+  }
+
+  const result: SpaceReputationFlatParams = {};
+
+  if (objectPresent) {
+    // Object form chosen. Read from the object; ignore the flat props entirely.
+    const spaceId = spaceReputation!.spaceId;
+    if (spaceId !== undefined && spaceId !== null) {
+      result.spaceReputationId = spaceId;
+    }
+    const includeDescendants = spaceReputation!.includeDescendants;
+    if (includeDescendants !== undefined && includeDescendants !== null) {
+      result.spaceReputationDescendants = includeDescendants;
+    }
+    return result;
+  }
+
+  // Flat form. `null` is treated as unset (param omitted).
+  if (spaceReputationId !== undefined && spaceReputationId !== null) {
+    result.spaceReputationId = spaceReputationId;
+  }
+  if (
+    spaceReputationDescendants !== undefined &&
+    spaceReputationDescendants !== null
+  ) {
+    result.spaceReputationDescendants = spaceReputationDescendants;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Phase 1–2 of the space-reputation consolidation (`@sublay/core`).

## What
Replaces the two flat reputation props (`spaceReputationId`, `spaceReputationDescendants`) repeated inline across ~22 hooks with a single `spaceReputation` object as the primary form, while keeping the flat props working (now `@deprecated`).

- **Infra:** new `SpaceReputationContextParams` / `SpaceReputationUserParams` interfaces (users variant rejects `"context"`) + `buildSpaceReputationParams` helper that normalizes either form to flat query params, with object-wins precedence, a one-time dev warning, and `null` tolerance for the entity-lists path.
- **Migration:** every reputation-consuming context- and users-variant hook now extends the shared types and routes params through the helper; entity-lists keeps its persisted Redux state flat and accepts the object only at the input boundary.

## Safety
The wire format is unchanged (still two query params) — backward-compatible by construction, zero server change. The object must never reach a serializer un-normalized (it would bracket-serialize / `[object Object]` and the server would silently ignore it). Serialization regression guards assert the object form serializes to flat `spaceReputationId=…&spaceReputationDescendants=…` across representative hooks, wrapper load-more paths, and the entity-lists `entityListsApi` path.

## Tests
Core suite green (1049 tests), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)