### PR TITLE
fix(core): stream useAskContent answers token-by-token in React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/monorepo",
-  "version": "7.6.2",
+  "version": "7.7.0",
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",
   "description": "Sublay: Build interactive apps with social features like comments, votes, feeds, user lists, notifications, and more.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/core",
-  "version": "7.6.2",
+  "version": "7.7.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/core/src/hooks/search/useAskContent.test.tsx
+++ b/packages/core/src/hooks/search/useAskContent.test.tsx
@@ -80,6 +80,22 @@ describe("useAskContent", () => {
     });
   });
 
+  it("opts react-native-fetch-api into incremental streaming via reactNative.textStreaming", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeStreamResponse([sse("done", {})]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHookWithAxios(() => useAskContent());
+
+    act(() => {
+      result.current.ask({ query: "hello" });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.reactNative).toEqual({ textStreaming: true });
+  });
+
   it("attaches an Authorization header when an access token is present", async () => {
     const fetchMock = vi.fn().mockResolvedValue(makeStreamResponse([sse("done", {})]));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/core/src/hooks/search/useAskContent.ts
+++ b/packages/core/src/hooks/search/useAskContent.ts
@@ -152,14 +152,22 @@ export default function useAskContent(): UseAskContentReturn {
         return s ? `?${s}` : "";
       })();
 
+      // `reactNative.textStreaming` opts react-native-fetch-api into incremental
+      // streaming, so `response.body` is a progressively-readable stream rather
+      // than a buffered blob resolved only at completion. It's an unknown key to
+      // standard/web `fetch`, which ignores extra RequestInit fields, so we send
+      // it unconditionally instead of branching on platform.
+      const init: RequestInit & { reactNative?: { textStreaming?: boolean } } = {
+        method: "POST",
+        headers,
+        body,
+        signal: controller.signal,
+        reactNative: { textStreaming: true },
+      };
+
       (async () => {
         try {
-          const response = await fetch(`${BASE_URL}/${projectId}/search/ask${queryString}`, {
-            method: "POST",
-            headers,
-            body,
-            signal: controller.signal,
-          });
+          const response = await fetch(`${BASE_URL}/${projectId}/search/ask${queryString}`, init);
 
           if (!response.ok) {
             const text = await response.text().catch(() => "");
@@ -178,8 +186,12 @@ export default function useAskContent(): UseAskContentReturn {
           if (!response.body) {
             setError(
               "Streaming is not supported in this environment. " +
-              "In React Native, install react-native-fetch-api, web-streams-polyfill, and react-native-polyfill-globals, " +
-              "then call polyfillGlobals() at app startup."
+              "In React Native, install react-native-fetch-api, web-streams-polyfill@^3, " +
+              "react-native-polyfill-globals, and text-encoding, then at app startup call the " +
+              "targeted sub-polyfills — polyfill() from react-native-polyfill-globals/src/encoding, " +
+              "/readable-stream, and /fetch (in that order). " +
+              "Prefer these over the all-in-one polyfillGlobals(), which also pulls the native " +
+              "react-native-get-random-values and forces a dev-client rebuild."
             );
             setLoading(false);
             return;

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/expo",
-  "version": "7.6.2",
+  "version": "7.7.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/react-js/package.json
+++ b/packages/react-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/react-js",
-  "version": "7.6.2",
+  "version": "7.7.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sublay/react-native",
-  "version": "7.6.2",
+  "version": "7.7.0",
   "private": false,
   "license": "Apache-2.0",
   "author": "Sublay, maintained by Yanay Tsabary",


### PR DESCRIPTION
## What

`useAskContent` issued its SSE fetch without `react-native-fetch-api`'s `reactNative.textStreaming` option, so in React Native the polyfilled `fetch` buffered the whole response into a blob and resolved `response.body` only at completion — the answer arrived in one burst instead of token-by-token, despite the hook advertising incremental streaming.

- Pass `reactNative: { textStreaming: true }` in the fetch init (an unknown, ignored key to standard/web fetch, so no platform branch). Typed via a local `RequestInit & { reactNative?… }` extension.
- Point the "streaming not supported" error at the targeted `react-native-polyfill-globals` sub-polyfills instead of `polyfillGlobals()`, which needlessly pulls the native `react-native-get-random-values` and forces a dev-client rebuild.
- Added a test asserting the flag is sent.

Also includes a `chore(release)` commit bumping all packages to 7.7.0 (previously-staged version bump).

## Verification
Full core suite green (1050 tests); `pnpm build` (ESM + CJS tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)