### PR TITLE
feat(core): add useMatchUsers hook

### DIFF
--- a/packages/core/src/hooks/search/index.ts
+++ b/packages/core/src/hooks/search/index.ts
@@ -21,3 +21,12 @@ export type {
 
 export { default as useAskContent } from "./useAskContent";
 export type { UseAskContentProps, UseAskContentReturn } from "./useAskContent";
+
+export { default as useMatchUsers } from "./useMatchUsers";
+export type {
+  UseMatchUsersProps,
+  UseMatchUsersReturn,
+  UserMatchResult,
+  MatchedFacet,
+  MatchFacetRef,
+} from "./useMatchUsers";

--- a/packages/core/src/hooks/search/index.ts
+++ b/packages/core/src/hooks/search/index.ts
@@ -29,4 +29,5 @@ export type {
   UserMatchResult,
   MatchedFacet,
   MatchFacetRef,
+  SampleContent,
 } from "./useMatchUsers";

--- a/packages/core/src/hooks/search/useMatchUsers.test.tsx
+++ b/packages/core/src/hooks/search/useMatchUsers.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+
+import {
+  renderHookWithAxios,
+  resetAxiosMocks,
+  makeAuthUser,
+} from "../../test-utils";
+import useMatchUsers from "./useMatchUsers";
+import type { UserMatchResult } from "./useMatchUsers";
+
+afterEach(() => {
+  resetAxiosMocks();
+});
+
+function makeMatch(overrides: Partial<UserMatchResult> = {}): UserMatchResult {
+  return {
+    user: makeAuthUser() as unknown as UserMatchResult["user"],
+    score: 1.23,
+    matchedFacets: [
+      {
+        similarity: 0.7,
+        askerFacet: { id: "af1", hotness: 4 },
+        candidateFacet: { id: "cf1", hotness: 4 },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("useMatchUsers", () => {
+  it("posts to /match/users and stores the { results } envelope", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useMatchUsers());
+
+    const results = [makeMatch()];
+    // The server returns the { results: [...] } envelope; the hook reads
+    // response.data.results.
+    axiosPrivate.mockResponse("post", { results });
+
+    await act(async () => {
+      await result.current.match({ mode: "passive", limit: 5 });
+    });
+
+    expect(result.current.results).toEqual(results);
+
+    const [call] = axiosPrivate.calls("post");
+    expect(call.url).toBe("/test-project/match/users");
+    // Body carries the mode + shaping fields (undefined for the ones not passed).
+    expect(call.body).toMatchObject({ mode: "passive", limit: 5 });
+  });
+
+  it("shapes the directed body (mode + query + flags)", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useMatchUsers());
+    axiosPrivate.mockResponse("post", { results: [] });
+
+    await act(async () => {
+      await result.current.match({
+        mode: "directed",
+        query: "biotech",
+        limit: 10,
+        spaceId: "space-1",
+        includeChildSpaces: true,
+        includeSampleContent: true,
+        excludeSelf: false,
+      });
+    });
+
+    const [call] = axiosPrivate.calls("post");
+    expect(call.url).toBe("/test-project/match/users");
+    expect(call.body).toEqual({
+      mode: "directed",
+      query: "biotech",
+      limit: 10,
+      spaceId: "space-1",
+      includeChildSpaces: true,
+      includeSampleContent: true,
+      excludeSelf: false,
+    });
+  });
+
+  it("does not call the API for a directed match with a blank query", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useMatchUsers());
+
+    await act(async () => {
+      await result.current.match({ mode: "directed", query: "   " });
+    });
+
+    expect(axiosPrivate.calls("post")).toHaveLength(0);
+  });
+
+  it("sets an error and stops loading when the server returns an error response", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useMatchUsers());
+
+    axiosPrivate.mockError("post", 403, {
+      error: "Interest matching is not enabled for this project",
+    });
+
+    await act(async () => {
+      await result.current.match({ mode: "passive" });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toContain("not enabled");
+  });
+
+  it("reset() clears results and error", async () => {
+    const { result, axiosPrivate } = renderHookWithAxios(() => useMatchUsers());
+
+    axiosPrivate.mockResponse("post", { results: [makeMatch()] });
+
+    await act(async () => {
+      await result.current.match({ mode: "passive" });
+    });
+    expect(result.current.results).toHaveLength(1);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/core/src/hooks/search/useMatchUsers.ts
+++ b/packages/core/src/hooks/search/useMatchUsers.ts
@@ -1,0 +1,95 @@
+import { useCallback, useState } from "react";
+import useProject from "../projects/useProject";
+import useAxiosPrivate from "../../config/useAxiosPrivate";
+import { handleError } from "../../utils/handleError";
+import { User } from "../../interfaces/models/User";
+
+export interface MatchFacetRef {
+  id: string;
+  hotness: number;
+}
+
+export interface MatchedFacet {
+  similarity: number;
+  askerFacet?: MatchFacetRef;
+  candidateFacet: MatchFacetRef;
+  sampleContent?: any[];
+}
+
+export interface UserMatchResult {
+  user: User;
+  score: number;
+  matchedFacets: MatchedFacet[];
+}
+
+export interface UseMatchUsersProps {
+  mode: "passive" | "directed";
+  query?: string;
+  limit?: number;
+  spaceId?: string;
+  includeChildSpaces?: boolean;
+  includeSampleContent?: boolean;
+  excludeSelf?: boolean;
+}
+
+export interface UseMatchUsersReturn {
+  results: UserMatchResult[];
+  loading: boolean;
+  error: string | null;
+  match: (props: UseMatchUsersProps) => Promise<void>;
+  reset: () => void;
+}
+
+export default function useMatchUsers(): UseMatchUsersReturn {
+  const { projectId } = useProject();
+  const axios = useAxiosPrivate();
+
+  const [results, setResults] = useState<UserMatchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const match = useCallback(
+    async ({
+      mode,
+      query,
+      limit,
+      spaceId,
+      includeChildSpaces,
+      includeSampleContent,
+      excludeSelf,
+    }: UseMatchUsersProps) => {
+      if (!projectId) return;
+      if (mode === "directed" && !query?.trim()) return;
+
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await axios.post<{ results: UserMatchResult[] }>(
+          `/${projectId}/match/users`,
+          {
+            mode,
+            query,
+            limit,
+            spaceId,
+            includeChildSpaces,
+            includeSampleContent,
+            excludeSelf,
+          }
+        );
+        setResults(response.data.results);
+      } catch (err) {
+        setError(handleError(err, "Failed to match users"));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [projectId, axios]
+  );
+
+  const reset = useCallback(() => {
+    setResults([]);
+    setError(null);
+  }, []);
+
+  return { results, loading, error, match, reset };
+}

--- a/packages/core/src/hooks/search/useMatchUsers.ts
+++ b/packages/core/src/hooks/search/useMatchUsers.ts
@@ -9,11 +9,18 @@ export interface MatchFacetRef {
   hotness: number;
 }
 
+export interface SampleContent {
+  sourceType: "entity" | "comment" | "message";
+  recordId: string;
+  content: string;
+  similarity: number;
+}
+
 export interface MatchedFacet {
   similarity: number;
   askerFacet?: MatchFacetRef;
   candidateFacet: MatchFacetRef;
-  sampleContent?: any[];
+  sampleContent?: SampleContent[];
 }
 
 export interface UserMatchResult {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -516,6 +516,7 @@ export {
   useSearchUsers,
   useSearchSpaces,
   useAskContent,
+  useMatchUsers,
   type UseSearchContentProps,
   type UseSearchContentReturn,
   type ContentSearchResult,
@@ -527,6 +528,11 @@ export {
   type SpaceSearchResult,
   type UseAskContentProps,
   type UseAskContentReturn,
+  type UseMatchUsersProps,
+  type UseMatchUsersReturn,
+  type UserMatchResult,
+  type MatchedFacet,
+  type MatchFacetRef,
 } from "./hooks/search";
 
 // -- storage

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -533,6 +533,7 @@ export {
   type UserMatchResult,
   type MatchedFacet,
   type MatchFacetRef,
+  type SampleContent,
 } from "./hooks/search";
 
 // -- storage


### PR DESCRIPTION
Adds `useMatchUsers` under `@sublay/core` (mirrors `useSearchUsers`), typed to the `{ results: [...] }` match envelope for the new `/match/users` endpoint. `sampleContent` is concretely typed as `SampleContent`, exported from `@sublay/core`. Re-exported automatically by react-js / react-native / expo. Includes a hook test (real timers).

Pairs with sublay-io/server-hosted#48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)