### PR TITLE
feat(core): search follows & connections by username/name

### DIFF
--- a/packages/core/src/hooks/relationships/connections/useFetchConnections.tsx
+++ b/packages/core/src/hooks/relationships/connections/useFetchConnections.tsx
@@ -4,8 +4,9 @@ import useProject from "../../projects/useProject";
 import { useUser } from "../../user";
 import { EstablishedConnection } from "../../../interfaces/models/Connection";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 
-export interface FetchConnectionsParams {
+export interface FetchConnectionsParams extends UserSearchParams {
   page?: number;
   limit?: number;
 }
@@ -19,7 +20,7 @@ function useFetchConnections(): (props?: FetchConnectionsParams) => Promise<Pagi
     async (
       props: FetchConnectionsParams = {}
     ): Promise<PaginatedResponse<EstablishedConnection>> => {
-      const { page = 1, limit = 20 } = props;
+      const { page = 1, limit = 20, query, searchFields } = props;
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -34,6 +35,8 @@ function useFetchConnections(): (props?: FetchConnectionsParams) => Promise<Pagi
           params: {
             page,
             limit,
+            query,
+            searchFields,
           },
         }
       );

--- a/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
+++ b/packages/core/src/hooks/relationships/connections/useFetchConnectionsByUserId.tsx
@@ -4,9 +4,12 @@ import { EstablishedConnection } from "../../../interfaces/models/Connection";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
 import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
-export interface FetchConnectionsByUserIdParams extends SpaceReputationUserParams {
+export interface FetchConnectionsByUserIdParams
+  extends SpaceReputationUserParams,
+    UserSearchParams {
   userId: string;
   page?: number;
   limit?: number;
@@ -19,7 +22,7 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
     async (
       props: FetchConnectionsByUserIdParams
     ): Promise<PaginatedResponse<EstablishedConnection>> => {
-      const { userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants } = props;
+      const { userId, page = 1, limit = 20, query, searchFields, spaceReputation, spaceReputationId, spaceReputationDescendants } = props;
       if (!projectId) {
         throw new Error("No project specified");
       }
@@ -31,6 +34,8 @@ function useFetchConnectionsByUserId(): (props: FetchConnectionsByUserIdParams) 
       const params: Record<string, any> = {
         page,
         limit,
+        query,
+        searchFields,
         ...buildSpaceReputationParams({
           spaceReputation,
           spaceReputationId,

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowers.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowers.tsx
@@ -4,6 +4,7 @@ import useProject from "../../projects/useProject";
 import { useUser } from "../../user";
 import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 
 export interface FollowerWithFollowInfo {
   followId: string;
@@ -11,7 +12,7 @@ export interface FollowerWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowersParams {
+export interface FetchFollowersParams extends UserSearchParams {
   page?: number;
   limit?: number;
 }
@@ -22,7 +23,7 @@ function useFetchFollowers(): (params?: FetchFollowersParams) => Promise<Paginat
   const { user } = useUser();
 
   const fetchFollowers = useCallback(
-    async ({ page = 1, limit = 20 }: FetchFollowersParams = {}) => {
+    async ({ page = 1, limit = 20, query, searchFields }: FetchFollowersParams = {}) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -34,7 +35,7 @@ function useFetchFollowers(): (params?: FetchFollowersParams) => Promise<Paginat
       const response = await axios.get<PaginatedResponse<FollowerWithFollowInfo>>(
         `/${projectId}/follows/followers`,
         {
-          params: { page, limit },
+          params: { page, limit, query, searchFields },
         }
       );
 

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowersByUserId.tsx
@@ -4,6 +4,7 @@ import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
 import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
 export interface FollowerWithFollowInfo {
@@ -12,7 +13,9 @@ export interface FollowerWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowersByUserIdParams extends SpaceReputationUserParams {
+export interface FetchFollowersByUserIdParams
+  extends SpaceReputationUserParams,
+    UserSearchParams {
   userId: string;
   page?: number;
   limit?: number;
@@ -22,7 +25,7 @@ function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => 
   const { projectId } = useProject();
 
   const fetchFollowersByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowersByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, query, searchFields, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowersByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -34,6 +37,8 @@ function useFetchFollowersByUserId(): (params: FetchFollowersByUserIdParams) => 
       const params: Record<string, any> = {
         page,
         limit,
+        query,
+        searchFields,
         ...buildSpaceReputationParams({
           spaceReputation,
           spaceReputationId,

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowing.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowing.tsx
@@ -4,6 +4,7 @@ import useProject from "../../projects/useProject";
 import { useUser } from "../../user";
 import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 
 export interface FollowingWithFollowInfo {
   followId: string;
@@ -11,7 +12,7 @@ export interface FollowingWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowingParams {
+export interface FetchFollowingParams extends UserSearchParams {
   page?: number;
   limit?: number;
 }
@@ -22,7 +23,7 @@ function useFetchFollowing(): (params?: FetchFollowingParams) => Promise<Paginat
   const { user } = useUser();
 
   const fetchFollowing = useCallback(
-    async ({ page = 1, limit = 20 }: FetchFollowingParams = {}) => {
+    async ({ page = 1, limit = 20, query, searchFields }: FetchFollowingParams = {}) => {
       if (!projectId) {
         throw new Error("No projectId available.");
       }
@@ -37,6 +38,8 @@ function useFetchFollowing(): (params?: FetchFollowingParams) => Promise<Paginat
           params: {
             page,
             limit,
+            query,
+            searchFields,
           },
         }
       );

--- a/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
+++ b/packages/core/src/hooks/relationships/follows/useFetchFollowingByUserId.tsx
@@ -4,6 +4,7 @@ import type { User } from "../../../interfaces/models/User";
 import { PaginatedResponse } from "../../../interfaces/PaginatedResponse";
 import axios from "../../../config/axios";
 import { SpaceReputationUserParams } from "../../../interfaces/SpaceReputation";
+import { UserSearchParams } from "../../../interfaces/UserSearch";
 import { buildSpaceReputationParams } from "../../../utils/spaceReputationParams";
 
 export interface FollowingWithFollowInfo {
@@ -12,7 +13,9 @@ export interface FollowingWithFollowInfo {
   followedAt: string;
 }
 
-export interface FetchFollowingByUserIdParams extends SpaceReputationUserParams {
+export interface FetchFollowingByUserIdParams
+  extends SpaceReputationUserParams,
+    UserSearchParams {
   userId: string;
   page?: number;
   limit?: number;
@@ -22,7 +25,7 @@ function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => 
   const { projectId } = useProject();
 
   const fetchFollowingByUserId = useCallback(
-    async ({ userId, page = 1, limit = 20, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowingByUserIdParams) => {
+    async ({ userId, page = 1, limit = 20, query, searchFields, spaceReputation, spaceReputationId, spaceReputationDescendants }: FetchFollowingByUserIdParams) => {
       if (!userId) {
         throw new Error("No userId provided.");
       }
@@ -34,6 +37,8 @@ function useFetchFollowingByUserId(): (params: FetchFollowingByUserIdParams) => 
       const params: Record<string, any> = {
         page,
         limit,
+        query,
+        searchFields,
         ...buildSpaceReputationParams({
           spaceReputation,
           spaceReputationId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -642,6 +642,7 @@ export type {
   SpaceReputationContextObject,
   SpaceReputationUserObject,
 } from "./interfaces/SpaceReputation";
+export type { UserSearchParams } from "./interfaces/UserSearch";
 export type {
   Rule,
   FetchManyRulesResponse,

--- a/packages/core/src/interfaces/UserSearch.ts
+++ b/packages/core/src/interfaces/UserSearch.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared optional params for text-searching a list of users
+ * (followers / following / connections).
+ *
+ * - `query` — free-text search term. When omitted, no filtering is applied.
+ * - `searchFields` — narrows which user field the term matches against. When
+ *   omitted, the term matches either `username` OR `name` (case-insensitive
+ *   substring). `"username"` / `"name"` restrict the match to that one field.
+ */
+export interface UserSearchParams {
+  query?: string;
+  searchFields?: "username" | "name";
+}


### PR DESCRIPTION
## Summary
Adds optional `query` + `searchFields` params (shared `UserSearchParams`) to the six `@sublay/core` follows/connections list hooks: `useFetchFollowers/Following`, `useFetchConnections`, and the three by-user-id variants.

Mirrors the v7 server contract exactly — omitting `query` is unfiltered; omitting `searchFields` matches either username or name. `UserSearchParams` is re-exported from core; react-js/react-native/expo inherit it via re-export. All 91 relationship hook tests pass.

Requires server PR sublay-io/server-hosted#49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)