### PR TITLE
feat(spaces): expose visibility on space create/update

### DIFF
--- a/packages/core/src/hooks/spaces/useCreateSpace.tsx
+++ b/packages/core/src/hooks/spaces/useCreateSpace.tsx
@@ -4,6 +4,7 @@ import {
   Space,
   ReadingPermission,
   PostingPermission,
+  SpaceVisibility,
 } from "../../interfaces/models/Space";
 import { UploadImageOptions } from "../../interfaces/models/Image";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
@@ -22,6 +23,7 @@ export interface CreateSpaceProps {
   banner?: ImageUploadConfig;
   readingPermission?: ReadingPermission;
   postingPermission?: PostingPermission;
+  visibility?: SpaceVisibility;
   requireJoinApproval?: boolean;
   metadata?: Record<string, any>;
   parentSpaceId?: string | null;
@@ -61,6 +63,9 @@ function useCreateSpace(): (props: CreateSpaceProps) => Promise<Space> {
         if (props.postingPermission) {
           formData.append("postingPermission", props.postingPermission);
         }
+        if (props.visibility) {
+          formData.append("visibility", props.visibility);
+        }
         if (props.requireJoinApproval !== undefined) {
           formData.append("requireJoinApproval", String(props.requireJoinApproval));
         }
@@ -96,6 +101,7 @@ function useCreateSpace(): (props: CreateSpaceProps) => Promise<Space> {
           description: props.description,
           readingPermission: props.readingPermission,
           postingPermission: props.postingPermission,
+          visibility: props.visibility,
           requireJoinApproval: props.requireJoinApproval,
           metadata: props.metadata,
           parentSpaceId: props.parentSpaceId,

--- a/packages/core/src/hooks/spaces/useUpdateSpace.tsx
+++ b/packages/core/src/hooks/spaces/useUpdateSpace.tsx
@@ -4,6 +4,7 @@ import {
   SpaceDetailed,
   ReadingPermission,
   PostingPermission,
+  SpaceVisibility,
 } from "../../interfaces/models/Space";
 import { UploadImageOptions } from "../../interfaces/models/Image";
 import useAxiosPrivate from "../../config/useAxiosPrivate";
@@ -25,6 +26,7 @@ export interface UpdateSpaceProps {
     banner: ImageUploadConfig;
     readingPermission: ReadingPermission;
     postingPermission: PostingPermission;
+    visibility: SpaceVisibility;
     requireJoinApproval: boolean;
     metadata: Record<string, any>;
   }>;
@@ -66,6 +68,9 @@ function useUpdateSpace(): (props: UpdateSpaceProps) => Promise<SpaceDetailed> {
         }
         if (update.postingPermission !== undefined) {
           formData.append("postingPermission", update.postingPermission);
+        }
+        if (update.visibility !== undefined) {
+          formData.append("visibility", update.visibility);
         }
         if (update.requireJoinApproval !== undefined) {
           formData.append(

--- a/packages/core/src/interfaces/models/Space.ts
+++ b/packages/core/src/interfaces/models/Space.ts
@@ -3,6 +3,7 @@ import { File } from "./File";
 
 export type ReadingPermission = "anyone" | "members";
 export type PostingPermission = "anyone" | "members" | "admins";
+export type SpaceVisibility = "public" | "unlisted" | "private";
 
 export type SpaceMemberRole = "admin" | "moderator" | "member";
 export type SpaceMemberStatus = "pending" | "active" | "banned" | "rejected";
@@ -25,6 +26,7 @@ export interface SpacePreview {
   slug: string | null;
   avatarFileId: string | null;
   readingPermission?: ReadingPermission;
+  visibility?: SpaceVisibility;
   parentSpaceId?: string | null;
   depth?: number;
 
@@ -49,6 +51,7 @@ export interface Space {
   userId: string;
   readingPermission: ReadingPermission;
   postingPermission: PostingPermission;
+  visibility: SpaceVisibility;
   requireJoinApproval: boolean;
 
   // Hierarchy

--- a/packages/core/src/store/api/spacesApi.ts
+++ b/packages/core/src/store/api/spacesApi.ts
@@ -16,6 +16,7 @@ interface CreateSpaceParams {
   banner?: string | null;
   readingPermission?: "anyone" | "members";
   postingPermission?: "anyone" | "members" | "admins";
+  visibility?: "public" | "unlisted" | "private";
   requireJoinApproval?: boolean;
   metadata?: Record<string, any>;
   parentSpaceId?: string | null;
@@ -61,6 +62,7 @@ interface UpdateSpaceParams {
     banner: string | null;
     readingPermission: "anyone" | "members";
     postingPermission: "anyone" | "members" | "admins";
+    visibility: "public" | "unlisted" | "private";
     requireJoinApproval: boolean;
     metadata: Record<string, any>;
   }>;

--- a/packages/core/src/test-utils/modelFactories.ts
+++ b/packages/core/src/test-utils/modelFactories.ts
@@ -131,6 +131,7 @@ export function makeSpace(overrides: Partial<Space> = {}): Space {
     userId: "user-1",
     readingPermission: "anyone",
     postingPermission: "anyone",
+    visibility: "public",
     requireJoinApproval: false,
     parentSpaceId: null,
     depth: 0,


### PR DESCRIPTION
Mirrors the server's new space `visibility` field (`public | unlisted | private`) in `@sublay/core`: `SpaceVisibility` type, `visibility` on the Space interface (optional on `SpacePreview`), optional `visibility` on `useCreateSpace`/`useUpdateSpace` (sent via multipart formData + JSON body), RTK Query param types, and the space test factory default. React/RN/Expo re-export core unchanged. No aliases or renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)